### PR TITLE
Add Legends of Runeterra APIs support (partially...)

### DIFF
--- a/BlossomiShymae.RiotBlossom/Api/Riot/LorMatchApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/Riot/LorMatchApi.cs
@@ -1,0 +1,51 @@
+﻿using BlossomiShymae.RiotBlossom.Core;
+using BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch;
+using BlossomiShymae.RiotBlossom.Http;
+using BlossomiShymae.RiotBlossom.Type;
+using System.Collections.Immutable;
+
+namespace BlossomiShymae.RiotBlossom.Api.Riot
+{
+    public interface ILorMatchApi
+    {
+        /// <summary>
+        /// Get the list of match IDs by PUUID.
+        /// </summary>
+        /// <param name="lorRegion"></param>
+        /// <param name="puuid"></param>
+        /// <returns></returns>
+        Task<ImmutableList<string>> ListIdsByPuuidAsync(LorRegion lorRegion, string puuid);
+        /// <summary>
+        /// Get match by ID.
+        /// </summary>
+        /// <param name="lorRegion"></param>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        Task<MatchDto> GetByIdAsync(LorRegion lorRegion, string id);
+
+    }
+
+    internal class LorMatchApi : ILorMatchApi
+    {
+        private static readonly string s_uri = "/lor/match/v1/matches";
+        private static readonly string s_matchByIdUri = s_uri + "/{0}";
+        private static readonly string s_listIdsByPuuidUri = s_uri + "/by-puuid/{0}/ids";
+        private readonly ComposableApi<List<string>> _stringsApi;
+        private readonly ComposableApi<MatchDto> _matchDtoApi;
+
+        public LorMatchApi(RiotHttpClient riotHttpClient)
+        {
+            _stringsApi = new(riotHttpClient);
+            _matchDtoApi = new(riotHttpClient);
+        }
+
+        public async Task<MatchDto> GetByIdAsync(LorRegion lorRegion, string id)
+            => await _matchDtoApi.GetValueAsync(LorRegionMapper.GetId(lorRegion), string.Format(s_matchByIdUri, id));
+
+        public async Task<ImmutableList<string>> ListIdsByPuuidAsync(LorRegion lorRegion, string puuid)
+        {
+            List<string> ids = await _stringsApi.GetValueAsync(LorRegionMapper.GetId(lorRegion), string.Format(s_listIdsByPuuidUri, puuid));
+            return ids.ToImmutableList();
+        }
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Api/Riot/LorRankedApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/Riot/LorRankedApi.cs
@@ -1,0 +1,31 @@
+﻿using BlossomiShymae.RiotBlossom.Core;
+using BlossomiShymae.RiotBlossom.Dto.Riot.LorRanked;
+using BlossomiShymae.RiotBlossom.Http;
+using BlossomiShymae.RiotBlossom.Type;
+
+namespace BlossomiShymae.RiotBlossom.Api.Riot
+{
+    public interface ILorRankedApi
+    {
+        /// <summary>
+        /// Get the player leaderboard in Master tier.
+        /// </summary>
+        /// <param name="lorRegion"></param>
+        /// <returns></returns>
+        Task<LeaderboardDto> GetMasterLeaderboardAsync(LorRegion lorRegion);
+    }
+
+    internal class LorRankedApi : ILorRankedApi
+    {
+        private static readonly string s_masterLeaderboardUri = "/lor/ranked/v1/leaderboards";
+        private readonly ComposableApi<LeaderboardDto> _leaderboardDtoApi;
+
+        public LorRankedApi(RiotHttpClient riotHttpClient)
+        {
+            _leaderboardDtoApi = new(riotHttpClient);
+        }
+
+        public Task<LeaderboardDto> GetMasterLeaderboardAsync(LorRegion lorRegion)
+            => _leaderboardDtoApi.GetValueAsync(LorRegionMapper.GetId(lorRegion), s_masterLeaderboardUri);
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Api/Riot/LorStatusApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/Riot/LorStatusApi.cs
@@ -1,0 +1,31 @@
+﻿using BlossomiShymae.RiotBlossom.Core;
+using BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus;
+using BlossomiShymae.RiotBlossom.Http;
+using BlossomiShymae.RiotBlossom.Type;
+
+namespace BlossomiShymae.RiotBlossom.Api.Riot
+{
+    public interface ILorStatusApi
+    {
+        /// <summary>
+        /// Get Legends of Runeterra status for the current region.
+        /// </summary>
+        /// <param name="regionRoute"></param>
+        /// <returns></returns>
+        Task<PlatformDataDto> GetPlatformStatusAsync(LorRegion regionRoute);
+    }
+
+    internal class LorStatusApi : ILorStatusApi
+    {
+        private static readonly string s_statusUri = "/lor/status/v1/platform-data";
+        private readonly ComposableApi<PlatformDataDto> _platformDataDtoApi;
+
+        public LorStatusApi(RiotHttpClient riotHttpClient)
+        {
+            _platformDataDtoApi = new(riotHttpClient);
+        }
+
+        public async Task<PlatformDataDto> GetPlatformStatusAsync(LorRegion regionRoute)
+            => await _platformDataDtoApi.GetValueAsync(LorRegionMapper.GetId(regionRoute), s_statusUri);
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
@@ -34,6 +34,10 @@ namespace BlossomiShymae.RiotBlossom.Api
         /// </summary>
         ILolStatusApi LolStatus { get; }
         /// <summary>
+        /// The API for Lor-Match-v1 endpoints.
+        /// </summary>
+        ILorMatchApi LorMatch { get; }
+        /// <summary>
         /// The API for Lor-Ranked-v1 endpoint.
         /// </summary>
         ILorRankedApi LorRanked { get; }
@@ -80,6 +84,7 @@ namespace BlossomiShymae.RiotBlossom.Api
         private readonly LeagueApi _leagueApi;
         private readonly LolChallengesApi _lolChallengesApi;
         private readonly LolStatusApi _lolStatusApi;
+        private readonly LorMatchApi _lorMatchApi;
         private readonly LorRankedApi _lorRankedApi;
         private readonly LorStatusApi _lorStatusApi;
         private readonly MatchApi _matchApi;
@@ -96,6 +101,7 @@ namespace BlossomiShymae.RiotBlossom.Api
         public ILeagueApi League => _leagueApi;
         public ILolChallengesApi LolChallenges => _lolChallengesApi;
         public ILolStatusApi LolStatus => _lolStatusApi;
+        public ILorMatchApi LorMatch => _lorMatchApi;
         public ILorRankedApi LorRanked => _lorRankedApi;
         public ILorStatusApi LorStatus => _lorStatusApi;
         public IMatchApi Match => _matchApi;
@@ -115,6 +121,7 @@ namespace BlossomiShymae.RiotBlossom.Api
             _leagueApi = new(riotHttpClient);
             _lolChallengesApi = new(riotHttpClient);
             _lolStatusApi = new(riotHttpClient);
+            _lorMatchApi = new(riotHttpClient);
             _lorRankedApi = new(riotHttpClient);
             _lorStatusApi = new(riotHttpClient);
             _matchApi = new(riotHttpClient);

--- a/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
@@ -34,6 +34,10 @@ namespace BlossomiShymae.RiotBlossom.Api
         /// </summary>
         ILolStatusApi LolStatus { get; }
         /// <summary>
+        /// The API for Lor-Status-v1 endpoint.
+        /// </summary>
+        ILorStatusApi LorStatus { get; }
+        /// <summary>
         /// The API for Match-v5 endpoints.
         /// </summary>
         IMatchApi Match { get; }
@@ -72,6 +76,7 @@ namespace BlossomiShymae.RiotBlossom.Api
         private readonly LeagueApi _leagueApi;
         private readonly LolChallengesApi _lolChallengesApi;
         private readonly LolStatusApi _lolStatusApi;
+        private readonly LorStatusApi _lorStatusApi;
         private readonly MatchApi _matchApi;
         private readonly SpectatorApi _spectatorApi;
         private readonly SummonerApi _summonerApi;
@@ -86,6 +91,7 @@ namespace BlossomiShymae.RiotBlossom.Api
         public ILeagueApi League => _leagueApi;
         public ILolChallengesApi LolChallenges => _lolChallengesApi;
         public ILolStatusApi LolStatus => _lolStatusApi;
+        public ILorStatusApi LorStatus => _lorStatusApi;
         public IMatchApi Match => _matchApi;
         public ISpectatorApi Spectator => _spectatorApi;
         public ISummonerApi Summoner => _summonerApi;
@@ -103,6 +109,7 @@ namespace BlossomiShymae.RiotBlossom.Api
             _leagueApi = new(riotHttpClient);
             _lolChallengesApi = new(riotHttpClient);
             _lolStatusApi = new(riotHttpClient);
+            _lorStatusApi = new(riotHttpClient);
             _matchApi = new(riotHttpClient);
             _spectatorApi = new(riotHttpClient);
             _summonerApi = new(riotHttpClient);

--- a/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
@@ -34,6 +34,10 @@ namespace BlossomiShymae.RiotBlossom.Api
         /// </summary>
         ILolStatusApi LolStatus { get; }
         /// <summary>
+        /// The API for Lor-Ranked-v1 endpoint.
+        /// </summary>
+        ILorRankedApi LorRanked { get; }
+        /// <summary>
         /// The API for Lor-Status-v1 endpoint.
         /// </summary>
         ILorStatusApi LorStatus { get; }
@@ -76,6 +80,7 @@ namespace BlossomiShymae.RiotBlossom.Api
         private readonly LeagueApi _leagueApi;
         private readonly LolChallengesApi _lolChallengesApi;
         private readonly LolStatusApi _lolStatusApi;
+        private readonly LorRankedApi _lorRankedApi;
         private readonly LorStatusApi _lorStatusApi;
         private readonly MatchApi _matchApi;
         private readonly SpectatorApi _spectatorApi;
@@ -91,6 +96,7 @@ namespace BlossomiShymae.RiotBlossom.Api
         public ILeagueApi League => _leagueApi;
         public ILolChallengesApi LolChallenges => _lolChallengesApi;
         public ILolStatusApi LolStatus => _lolStatusApi;
+        public ILorRankedApi LorRanked => _lorRankedApi;
         public ILorStatusApi LorStatus => _lorStatusApi;
         public IMatchApi Match => _matchApi;
         public ISpectatorApi Spectator => _spectatorApi;
@@ -109,6 +115,7 @@ namespace BlossomiShymae.RiotBlossom.Api
             _leagueApi = new(riotHttpClient);
             _lolChallengesApi = new(riotHttpClient);
             _lolStatusApi = new(riotHttpClient);
+            _lorRankedApi = new(riotHttpClient);
             _lorStatusApi = new(riotHttpClient);
             _matchApi = new(riotHttpClient);
             _spectatorApi = new(riotHttpClient);

--- a/BlossomiShymae.RiotBlossom/Core/IntJsonConverter.cs
+++ b/BlossomiShymae.RiotBlossom/Core/IntJsonConverter.cs
@@ -1,0 +1,18 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BlossomiShymae.RiotBlossom.Core
+{
+    internal class IntJsonConverter : JsonConverter<int>
+    {
+        public override int Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+        {
+            double floating = reader.GetDouble();
+            int integer = (int)floating;
+            return integer == floating ? integer : reader.GetInt32();
+        }
+
+        public override void Write(Utf8JsonWriter writer, int value, JsonSerializerOptions options)
+            => writer.WriteNumberValue(value);
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Core/LorRegionMapper.cs
+++ b/BlossomiShymae.RiotBlossom/Core/LorRegionMapper.cs
@@ -1,0 +1,36 @@
+﻿using BlossomiShymae.RiotBlossom.Type;
+using System.Collections.Immutable;
+
+namespace BlossomiShymae.RiotBlossom.Core
+{
+    /// <summary>
+    /// A mapper class for the <see cref="LorRegion"/> enum. Used for obtaining the raw value.
+    /// </summary>
+    public static class LorRegionMapper
+    {
+        private static readonly ImmutableDictionary<LorRegion, string> s_regionByRoute =
+            new Dictionary<LorRegion, string>
+            {
+                { LorRegion.Americas, "americas" },
+                { LorRegion.Europe, "europe" },
+                { LorRegion.SouthEastAsia, "sea" }
+            }.ToImmutableDictionary();
+
+        public static string GetId(LorRegion lorRegion)
+        {
+            string? region = s_regionByRoute.GetValueOrDefault(lorRegion);
+            return region ?? throw new NotImplementedException($"LoR region for regional route {lorRegion} not implemented");
+        }
+
+        public static LorRegion FromId(string id)
+        {
+            var kvpList = s_regionByRoute.ToList();
+            foreach (var kv in kvpList)
+            {
+                if (kv.Value == id)
+                    return kv.Key;
+            }
+            throw new NotImplementedException($"Could not find LoR region for id {id}");
+        }
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/InfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/InfoDto.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
+{
+    public record InfoDto
+    {
+        /// <summary>
+        /// The current game mode. (Legal values: Constructed, Expeditions, Tutorial)
+        /// </summary>
+        [JsonPropertyName("game_mode")]
+        public string GameMode { get; init; } = default!;
+        /// <summary>
+        /// The current game type. (Legal values: Ranked, Normal, AI, Tutorial, VanillaTrial, Singleton, StandardGauntlet)
+        /// </summary>
+        [JsonPropertyName("game_type")]
+        public string GameType { get; init; } = default!;
+        /// <summary>
+        /// The time the game has started in Coordinated Universal Time.
+        /// </summary>
+        [JsonPropertyName("game_start_time_utc")]
+        public string GameStartTimeUtc { get; init; } = default!;
+        /// <summary>
+        /// The current game version.
+        /// </summary>
+        [JsonPropertyName("game_version")]
+        public string GameVersion { get; init; } = default!;
+        /// <summary>
+        /// The players participating in game.
+        /// </summary>
+        public ImmutableList<PlayerDto> Players { get; init; } = ImmutableList<PlayerDto>.Empty;
+        /// <summary>
+        /// The total turns taken by both players.
+        /// </summary>
+        [JsonPropertyName("total_turn_count")]
+        public int TotalTurnCount { get; init; }
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/MatchDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/MatchDto.cs
@@ -1,0 +1,14 @@
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
+{
+    public record MatchDto
+    {
+        /// <summary>
+        /// The match metadata.
+        /// </summary>
+        public MetadataDto Metadata { get; init; } = new();
+        /// <summary>
+        /// The match info.
+        /// </summary>
+        public InfoDto Info { get; init; } = new();
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/MetadataDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/MetadataDto.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
+{
+    public record MetadataDto
+    {
+        /// <summary>
+        /// The match data version.
+        /// </summary>
+        [JsonPropertyName("data_version")]
+        public string DataVersion { get; init; } = default!;
+        /// <summary>
+        /// The match ID.
+        /// </summary>
+        [JsonPropertyName("match_id")]
+        public string MatchId { get; init; } = default!;
+        /// <summary>
+        /// The list of participant PUUIDs.
+        /// </summary>
+        public ImmutableList<string> Participants { get; init; } = ImmutableList<string>.Empty;
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/PlayerDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/PlayerDto.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Immutable;
+using System.Text.Json.Serialization;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
+{
+    public record PlayerDto
+    {
+        /// <summary>
+        /// The player UUID.
+        /// </summary>
+        public string Puuid { get; init; } = default!;
+        /// <summary>
+        /// The ID for the deck played.
+        /// </summary>
+        [JsonPropertyName("deck_id")]
+        public string DeckId { get; init; } = default!;
+        /// <summary>
+        /// The code for the deck played.
+        /// </summary>
+        [JsonPropertyName("deck_code")]
+        public string DeckCode { get; init; } = default!;
+        public ImmutableList<string> Factions { get; init; } = ImmutableList<string>.Empty;
+        [JsonPropertyName("game_outcome")]
+        public string GameOutcome { get; init; } = default!;
+        /// <summary>
+        /// The order in which the players took turns.
+        /// </summary>
+        [JsonPropertyName("order_of_play")]
+        public int OrderOfPlayer { get; init; }
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorRanked/LeaderboardDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorRanked/LeaderboardDto.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Immutable;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorRanked
+{
+    public record LeaderboardDto
+    {
+        /// <summary>
+        /// The list of players in Master tier.
+        /// </summary>
+        public ImmutableList<PlayerDto> Players { get; init; } = ImmutableList<PlayerDto>.Empty;
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorRanked/PlayerDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorRanked/PlayerDto.cs
@@ -1,0 +1,18 @@
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorRanked
+{
+    public record PlayerDto
+    {
+        /// <summary>
+        /// The player name.
+        /// </summary>
+        public string Name { get; init; } = default!;
+        /// <summary>
+        /// The rank of player.
+        /// </summary>
+        public int Rank { get; init; }
+        /// <summary>
+        /// The League points of player.
+        /// </summary>
+        public int Lp { get; init; }
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorRanked/PlayerDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorRanked/PlayerDto.cs
@@ -1,4 +1,7 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorRanked
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Text.Json.Serialization;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorRanked
 {
     public record PlayerDto
     {
@@ -11,8 +14,11 @@
         /// </summary>
         public int Rank { get; init; }
         /// <summary>
-        /// The League points of player.
+        /// <para>The League points of player.</para>
+        /// <para>Note: RiotBlossom deserializes from floating-point to int due to returned data type not matching the schema.</para>
+        /// <para>See Developer Relations issue <see href="https://github.com/RiotGames/developer-relations/issues/345"/>.</para>
         /// </summary>
+        [JsonConverter(typeof(IntJsonConverter))]
         public int Lp { get; init; }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Type/LorRegion.cs
+++ b/BlossomiShymae.RiotBlossom/Type/LorRegion.cs
@@ -1,7 +1,10 @@
-﻿namespace BlossomiShymae.RiotBlossom.Type
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Type
 {
     /// <summary>
     /// <para>An enum that serves as a representation of regional routing values for Legends of Runeterra.</para>
+    /// <para>See <see cref="LorRegionMapper"/>.</para>
     /// </summary>
     public enum LorRegion
     {

--- a/BlossomiShymae.RiotBlossom/Type/LorRegion.cs
+++ b/BlossomiShymae.RiotBlossom/Type/LorRegion.cs
@@ -1,0 +1,12 @@
+﻿namespace BlossomiShymae.RiotBlossom.Type
+{
+    /// <summary>
+    /// <para>An enum that serves as a representation of regional routing values for Legends of Runeterra.</para>
+    /// </summary>
+    public enum LorRegion
+    {
+        Americas,
+        Europe,
+        SouthEastAsia
+    }
+}

--- a/BlossomiShymae.RiotBlossomTests/Api/Riot/LorMatchApiTests.cs
+++ b/BlossomiShymae.RiotBlossomTests/Api/Riot/LorMatchApiTests.cs
@@ -1,0 +1,46 @@
+﻿using BlossomiShymae.RiotBlossom.Core;
+using BlossomiShymae.RiotBlossom.Dto.Riot.Account;
+using BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch;
+using BlossomiShymae.RiotBlossom.Dto.Riot.LorRanked;
+using BlossomiShymae.RiotBlossom.Type;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Immutable;
+
+namespace BlossomiShymae.RiotBlossomTests.Api.Riot
+{
+    [TestClass()]
+    public class LorMatchApiTests
+    {
+        public static AccountDto Account = default!;
+        public static string MatchId = "fb053415-b5a9-4c45-85a6-8553c8245c34";
+
+        [ClassInitialize()]
+        public static async Task Initialize(TestContext testContext)
+        {
+            IRiotBlossomClient client = StubConfig.Client;
+
+            LeaderboardDto leaderboard = await client.Riot.LorRanked.GetMasterLeaderboardAsync(LorRegion.Americas);
+            Account = await client.Riot.Account.GetAccountByRiotIdAsync(Region.Americas, leaderboard.Players.First().Name, "na1");
+        }
+
+        [TestMethod()]
+        public async Task Api_WithPuuid_ShouldReturnMatchIdCollection()
+        {
+            IRiotBlossomClient client = StubConfig.Client;
+
+            ImmutableList<string> ids = await client.Riot.LorMatch.ListIdsByPuuidAsync(LorRegion.Americas, Account.Puuid);
+
+            Assert.IsInstanceOfType(ids, typeof(ImmutableList<string>));
+        }
+
+        [TestMethod()]
+        public async Task Api_WithId_ShouldReturnMatchDto()
+        {
+            IRiotBlossomClient client = StubConfig.Client;
+
+            MatchDto dto = await client.Riot.LorMatch.GetByIdAsync(LorRegion.Americas, MatchId);
+
+            Assert.IsInstanceOfType(dto, typeof(MatchDto));
+        }
+    }
+}

--- a/BlossomiShymae.RiotBlossomTests/Api/Riot/LorRankedApiTests.cs
+++ b/BlossomiShymae.RiotBlossomTests/Api/Riot/LorRankedApiTests.cs
@@ -1,0 +1,21 @@
+﻿using BlossomiShymae.RiotBlossom.Core;
+using BlossomiShymae.RiotBlossom.Dto.Riot.LorRanked;
+using BlossomiShymae.RiotBlossom.Type;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BlossomiShymae.RiotBlossomTests.Api.Riot
+{
+    [TestClass()]
+    public class LorRankedApiTests
+    {
+        [TestMethod()]
+        public async Task Api_ByDefault_ShouldReturnLeaderboardDto()
+        {
+            IRiotBlossomClient client = StubConfig.Client;
+
+            LeaderboardDto dto = await client.Riot.LorRanked.GetMasterLeaderboardAsync(LorRegion.Americas);
+
+            Assert.IsInstanceOfType(dto, typeof(LeaderboardDto));
+        }
+    }
+}

--- a/BlossomiShymae.RiotBlossomTests/Api/Riot/LorStatusApiTests.cs
+++ b/BlossomiShymae.RiotBlossomTests/Api/Riot/LorStatusApiTests.cs
@@ -1,0 +1,21 @@
+﻿using BlossomiShymae.RiotBlossom.Core;
+using BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus;
+using BlossomiShymae.RiotBlossom.Type;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BlossomiShymae.RiotBlossomTests.Api.Riot
+{
+    [TestClass()]
+    public class LorStatusApiTests
+    {
+        [TestMethod()]
+        public async Task Api_ByDefault_ShouldReturnPlatformDataDto()
+        {
+            IRiotBlossomClient client = StubConfig.Client;
+
+            PlatformDataDto dto = await client.Riot.LorStatus.GetPlatformStatusAsync(LorRegion.Americas);
+
+            Assert.IsInstanceOfType(dto, typeof(PlatformDataDto));
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Made with [contrib.rocks](https://contrib.rocks).
     - Extensible subsystems (one for Riot API, one for the rest)
 - Reuseable data transfer objects, types, and exceptions
 - Common utilities (mappers and converters)
+- Riot Games API support (yep!)
+    - League of Legends
+    - Teamfight Tactics
+    - Legends of Runeterra
 - DataDragon support
 - CommunityDragon support
 - Love (੭ु ›ω‹ )੭ु⁾⁾♡
@@ -86,11 +90,11 @@ dotnet add package BlossomiShymae.RiotBlossom
 - ⭕ Tft-Summoner-v1 (no RSO)
 
 ### Legends of Runeterra
-- ➖ Lor-Deck-v1
-- ➖ Lor-Inventory-v1
-- ➖ Lor-Match-v1
-- ➖ Lor-Ranked-v1
-- ➖ Lor-Status-v1
+- ⭕ Lor-Deck-v1 (no RSO, currently not supported)
+- ⭕ Lor-Inventory-v1 (no RSO, currently not supported)
+- ✅ Lor-Match-v1
+- ✅ Lor-Ranked-v1
+- ✅ Lor-Status-v1
 
 ### Valorant
 - ➖ Val-Content-v1
@@ -442,6 +446,7 @@ RiotBlossom uses types to represent named values used for the Riot Games API.
 - `LeagueDivision`
 - `LeagueQueue`
 - `LeagueTier`
+- `LorRegion`
 - `TftLeagueQueue`
 - `Platform`
 - `Region`
@@ -459,16 +464,19 @@ Represents League ranked queue types for `league-v4`.
 ## LeagueTier
 Represents League ranks for `league-v4`.
 
+## LorRegion
+Represents the available regional routing values used for Legends of Runeterra.
+
 ## TftLeagueQueue
 Represents Teamfight Tactics ranked queue types for `tft-league-v1`.
 
 ## Platform
-Represents the available platform routing values used for the Riot API.
+Represents the available platform routing values used for the Riot API (League of Legends).
 
 [Refer to Developer docs to better understand how routing values work.](https://developer.riotgames.com/docs/lol#routing-values) <3
 
 ## Region
-Represents the available regional routing values used for the Riot API.
+Represents the available regional routing values used for the Riot API (League of Legends).
 
 [Refer to Developer docs to better understand how routing values work.](https://developer.riotgames.com/docs/lol#routing-values) <3
 
@@ -481,6 +489,7 @@ These are used internally for projecting values when making requests to the Riot
 - `LeagueDivisionMapper`
 - `LeagueQueueMapper`
 - `LeagueTierMapper`
+- `LorRegionMapper`
 - `TftLeagueQueueMapper`
 - `PlatformMapper`
 - `PlatformToRegionConverter`


### PR DESCRIPTION
Resolves #2 !

# Legends of Runeterra support

- Add `lor-match-v1` endpoint via `ILorMatch`, `LorMatch`
- Add `lor-ranked-v1` endpoint via `ILorRanked`, `LorRanked`
- Add `lor-status-v1` endpoint via `ILorStatus`, `LorStatus`

## Classes

- Add `LorRegion` enum and `LorRegionMapper` mapper
- Add new records under `Dto.Riot`namespace
  - `LorRanked.PlayerDto`
  - `LorRanked.LeaderboardDto`
  - `LorMatch.InfoDto`
  - `LorMatch.MatchDto`
  - `LorMatch.MetadataDto`
  - `LorMatch.PlayerDto`