### PR TITLE
Add VALORANT APIs support

### DIFF
--- a/BlossomiShymae.RiotBlossom/Api/Riot/ValContentApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/Riot/ValContentApi.cs
@@ -1,0 +1,41 @@
+﻿using BlossomiShymae.RiotBlossom.Core;
+using BlossomiShymae.RiotBlossom.Dto.Riot.ValContent;
+using BlossomiShymae.RiotBlossom.Http;
+using BlossomiShymae.RiotBlossom.Type;
+
+namespace BlossomiShymae.RiotBlossom.Api.Riot
+{
+    public interface IValContentApi
+    {
+        /// <summary>
+        /// Get VALORANT content.
+        /// </summary>
+        /// <param name="valRegion"></param>
+        /// <returns></returns>
+        Task<ContentDto> GetContentAsync(ValRegion valRegion);
+        /// <summary>
+        /// Get VALORANT content filtered by locale.
+        /// </summary>
+        /// <param name="valRegion"></param>
+        /// <param name="locale"></param>
+        /// <returns></returns>
+        Task<ContentDto> GetContentByLocaleAsync(ValRegion valRegion, string locale);
+    }
+
+    internal class ValContentApi : IValContentApi
+    {
+        private static readonly string s_uri = "/val/content/v1/contents";
+        private readonly ComposableApi<ContentDto> _contentDtoApi;
+
+        public ValContentApi(RiotHttpClient riotHttpClient)
+        {
+            _contentDtoApi = new(riotHttpClient);
+        }
+
+        public async Task<ContentDto> GetContentAsync(ValRegion valRegion)
+            => await _contentDtoApi.GetValueAsync(ValRegionMapper.GetId(valRegion), s_uri);
+
+        public async Task<ContentDto> GetContentByLocaleAsync(ValRegion valRegion, string locale)
+            => await _contentDtoApi.GetValueAsync(ValRegionMapper.GetId(valRegion), $"{s_uri}?locale={locale}");
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Api/Riot/ValMatchApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/Riot/ValMatchApi.cs
@@ -1,0 +1,59 @@
+﻿using BlossomiShymae.RiotBlossom.Core;
+using BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch;
+using BlossomiShymae.RiotBlossom.Http;
+using BlossomiShymae.RiotBlossom.Type;
+
+namespace BlossomiShymae.RiotBlossom.Api.Riot
+{
+    public interface IValMatchApi
+    {
+        /// <summary>
+        /// Get a VALORANT match by ID.
+        /// </summary>
+        /// <param name="valRegion"></param>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        Task<MatchDto> GetByIdAsync(ValRegion valRegion, string id);
+        /// <summary>
+        /// Get a <see cref="MatchlistDto"/> by PUUID.
+        /// </summary>
+        /// <param name="valRegion"></param>
+        /// <param name="puuid"></param>
+        /// <returns></returns>
+        Task<MatchlistDto> GetMatchlistByPuuidAsync(ValRegion valRegion, string puuid);
+        /// <summary>
+        /// Get recent matches by queue.
+        /// </summary>
+        /// <param name="valRegion"></param>
+        /// <param name="queue"></param>
+        /// <returns></returns>
+        Task<RecentMatchesDto> GetRecentMatchesByQueueAsync(ValRegion valRegion, string queue);
+    }
+
+    internal class ValMatchApi : IValMatchApi
+    {
+        private static readonly string s_uri = "/val/match/v1";
+        private static readonly string s_matchByIdUri = s_uri + "/matches/{0}";
+        private static readonly string s_matchlistsByPuuidUri = s_uri + "/matchlists/by-puuid/{0}";
+        private static readonly string s_recentMatchesByQueueUri = s_uri + "/recent-matches/by-queue/{0}";
+        private readonly ComposableApi<MatchDto> _matchApi;
+        private readonly ComposableApi<MatchlistDto> _matchlistApi;
+        private readonly ComposableApi<RecentMatchesDto> _recentMatchesApi;
+
+        public ValMatchApi(RiotHttpClient riotHttpClient)
+        {
+            _matchApi = new(riotHttpClient);
+            _matchlistApi = new(riotHttpClient);
+            _recentMatchesApi = new(riotHttpClient);
+        }
+
+        public async Task<MatchDto> GetByIdAsync(ValRegion valRegion, string id)
+            => await _matchApi.GetValueAsync(ValRegionMapper.GetId(valRegion), string.Format(s_matchByIdUri, id));
+
+        public async Task<MatchlistDto> GetMatchlistByPuuidAsync(ValRegion valRegion, string puuid)
+            => await _matchlistApi.GetValueAsync(ValRegionMapper.GetId(valRegion), string.Format(s_matchlistsByPuuidUri, puuid));
+
+        public async Task<RecentMatchesDto> GetRecentMatchesByQueueAsync(ValRegion valRegion, string queue)
+            => await _recentMatchesApi.GetValueAsync(ValRegionMapper.GetId(valRegion), string.Format(s_recentMatchesByQueueUri, queue));
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Api/Riot/ValRankedApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/Riot/ValRankedApi.cs
@@ -1,0 +1,49 @@
+﻿using BlossomiShymae.RiotBlossom.Core;
+using BlossomiShymae.RiotBlossom.Dto.Riot.ValRanked;
+using BlossomiShymae.RiotBlossom.Http;
+using BlossomiShymae.RiotBlossom.Type;
+
+namespace BlossomiShymae.RiotBlossom.Api.Riot
+{
+    public interface IValRankedApi
+    {
+        /// <summary>
+        /// Get leaderboard for the competitive queue by act ID.
+        /// </summary>
+        /// <param name="valRegion"></param>
+        /// <param name="actId"></param>
+        /// <returns></returns>
+        Task<LeaderboardDto> GetLeaderboardByActIdAsync(ValRegion valRegion, string actId);
+        /// <summary>
+        /// Get leaderboard for the competitive queue by act ID with options.
+        /// </summary>
+        /// <param name="valRegion"></param>
+        /// <param name="actId"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        Task<LeaderboardDto> GetLeaderboardByActIdAsync(ValRegion valRegion, string actId, GetLeaderboardByActIdAsyncOptions options);
+    }
+
+    internal class ValRankedApi : IValRankedApi
+    {
+        private static readonly string s_uri = "/val/ranked/v1/leaderboards/by-act/{0}";
+        private readonly ComposableApi<LeaderboardDto> _leaderboardApi;
+
+        public ValRankedApi(RiotHttpClient riotHttpClient)
+        {
+            _leaderboardApi = new(riotHttpClient);
+        }
+
+        public async Task<LeaderboardDto> GetLeaderboardByActIdAsync(ValRegion valRegion, string actId)
+            => await _leaderboardApi.GetValueAsync(ValRegionMapper.GetId(valRegion), string.Format(s_uri, actId));
+
+        public async Task<LeaderboardDto> GetLeaderboardByActIdAsync(ValRegion valRegion, string actId, GetLeaderboardByActIdAsyncOptions options)
+            => await _leaderboardApi.GetValueAsync(ValRegionMapper.GetId(valRegion), string.Format(s_uri, actId) + PropertiesToQueryConverter.ToQuery(options));
+    }
+
+    public record GetLeaderboardByActIdAsyncOptions
+    {
+        public int? Size { get; init; }
+        public int? StartIndex { get; init; }
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Api/Riot/ValStatusApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/Riot/ValStatusApi.cs
@@ -1,0 +1,31 @@
+﻿using BlossomiShymae.RiotBlossom.Core;
+using BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus;
+using BlossomiShymae.RiotBlossom.Http;
+using BlossomiShymae.RiotBlossom.Type;
+
+namespace BlossomiShymae.RiotBlossom.Api.Riot
+{
+    public interface IValStatusApi
+    {
+        /// <summary>
+        /// Get VALORANT status for the given platform.
+        /// </summary>
+        /// <param name="valRegion"></param>
+        /// <returns></returns>
+        Task<PlatformDataDto> GetPlatformStatusAsync(ValRegion valRegion);
+    }
+
+    internal class ValStatusApi : IValStatusApi
+    {
+        private static readonly string s_uri = "/val/status/v1/platform-data";
+        private readonly ComposableApi<PlatformDataDto> _platformDataDtoApi;
+
+        public ValStatusApi(RiotHttpClient riotHttpClient)
+        {
+            _platformDataDtoApi = new(riotHttpClient);
+        }
+
+        public async Task<PlatformDataDto> GetPlatformStatusAsync(ValRegion valRegion)
+            => await _platformDataDtoApi.GetValueAsync(ValRegionMapper.GetId(valRegion), s_uri);
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
@@ -74,6 +74,10 @@ namespace BlossomiShymae.RiotBlossom.Api
         /// </summary>
         ITftSummonerApi TftSummoner { get; }
         /// <summary>
+        /// The API for Val-Content-v1 endpoint.
+        /// </summary>
+        IValContentApi ValContent { get; }
+        /// <summary>
         /// The API for Val-Status-v1 endpoint.
         /// </summary>
         IValStatusApi ValStatus { get; }
@@ -98,6 +102,7 @@ namespace BlossomiShymae.RiotBlossom.Api
         private readonly TftMatchApi _tftMatchApi;
         private readonly TftStatusApi _tftStatusApi;
         private readonly TftSummonerApi _tftSummonerApi;
+        private readonly ValContentApi _valContentApi;
         private readonly ValStatusApi _valStatusApi;
         public IAccountApi Account => _accountApi;
         public IChampionApi Champion => _championApi;
@@ -116,6 +121,7 @@ namespace BlossomiShymae.RiotBlossom.Api
         public ITftMatchApi TftMatch => _tftMatchApi;
         public ITftStatusApi TftStatus => _tftStatusApi;
         public ITftSummonerApi TftSummoner => _tftSummonerApi;
+        public IValContentApi ValContent => _valContentApi;
         public IValStatusApi ValStatus => _valStatusApi;
 
         public RiotApi(RiotHttpClient riotHttpClient)
@@ -137,6 +143,7 @@ namespace BlossomiShymae.RiotBlossom.Api
             _tftMatchApi = new(riotHttpClient);
             _tftStatusApi = new(riotHttpClient);
             _tftSummonerApi = new(riotHttpClient);
+            _valContentApi = new(riotHttpClient);
             _valStatusApi = new(riotHttpClient);
         }
     }

--- a/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
@@ -78,6 +78,11 @@ namespace BlossomiShymae.RiotBlossom.Api
         /// </summary>
         IValContentApi ValContent { get; }
         /// <summary>
+        /// <para>The API for Val-Match-v1 endpoint.</para>
+        /// <para>Note: This API requires an authorized production API key for access!</para>
+        /// </summary>
+        IValMatchApi ValMatch { get; }
+        /// <summary>
         /// The API for Val-Ranked-v1 endpoint.
         /// </summary>
         IValRankedApi ValRanked { get; }
@@ -107,6 +112,7 @@ namespace BlossomiShymae.RiotBlossom.Api
         private readonly TftStatusApi _tftStatusApi;
         private readonly TftSummonerApi _tftSummonerApi;
         private readonly ValContentApi _valContentApi;
+        private readonly ValMatchApi _valMatchApi;
         private readonly ValRankedApi _valRankedApi;
         private readonly ValStatusApi _valStatusApi;
         public IAccountApi Account => _accountApi;
@@ -127,6 +133,7 @@ namespace BlossomiShymae.RiotBlossom.Api
         public ITftStatusApi TftStatus => _tftStatusApi;
         public ITftSummonerApi TftSummoner => _tftSummonerApi;
         public IValContentApi ValContent => _valContentApi;
+        public IValMatchApi ValMatch => _valMatchApi;
         public IValRankedApi ValRanked => _valRankedApi;
         public IValStatusApi ValStatus => _valStatusApi;
 
@@ -150,6 +157,7 @@ namespace BlossomiShymae.RiotBlossom.Api
             _tftStatusApi = new(riotHttpClient);
             _tftSummonerApi = new(riotHttpClient);
             _valContentApi = new(riotHttpClient);
+            _valMatchApi = new(riotHttpClient);
             _valRankedApi = new(riotHttpClient);
             _valStatusApi = new(riotHttpClient);
         }

--- a/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
@@ -73,6 +73,10 @@ namespace BlossomiShymae.RiotBlossom.Api
         /// The API for Tft-Summoner-v1 endpoints.
         /// </summary>
         ITftSummonerApi TftSummoner { get; }
+        /// <summary>
+        /// The API for Val-Status-v1 endpoint.
+        /// </summary>
+        IValStatusApi ValStatus { get; }
     }
 
     internal class RiotApi : IRiotApi
@@ -94,6 +98,7 @@ namespace BlossomiShymae.RiotBlossom.Api
         private readonly TftMatchApi _tftMatchApi;
         private readonly TftStatusApi _tftStatusApi;
         private readonly TftSummonerApi _tftSummonerApi;
+        private readonly ValStatusApi _valStatusApi;
         public IAccountApi Account => _accountApi;
         public IChampionApi Champion => _championApi;
         public IChampionMasteryApi ChampionMastery => _championMasteryApi;
@@ -111,6 +116,7 @@ namespace BlossomiShymae.RiotBlossom.Api
         public ITftMatchApi TftMatch => _tftMatchApi;
         public ITftStatusApi TftStatus => _tftStatusApi;
         public ITftSummonerApi TftSummoner => _tftSummonerApi;
+        public IValStatusApi ValStatus => _valStatusApi;
 
         public RiotApi(RiotHttpClient riotHttpClient)
         {
@@ -131,6 +137,7 @@ namespace BlossomiShymae.RiotBlossom.Api
             _tftMatchApi = new(riotHttpClient);
             _tftStatusApi = new(riotHttpClient);
             _tftSummonerApi = new(riotHttpClient);
+            _valStatusApi = new(riotHttpClient);
         }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
@@ -78,6 +78,10 @@ namespace BlossomiShymae.RiotBlossom.Api
         /// </summary>
         IValContentApi ValContent { get; }
         /// <summary>
+        /// The API for Val-Ranked-v1 endpoint.
+        /// </summary>
+        IValRankedApi ValRanked { get; }
+        /// <summary>
         /// The API for Val-Status-v1 endpoint.
         /// </summary>
         IValStatusApi ValStatus { get; }
@@ -103,6 +107,7 @@ namespace BlossomiShymae.RiotBlossom.Api
         private readonly TftStatusApi _tftStatusApi;
         private readonly TftSummonerApi _tftSummonerApi;
         private readonly ValContentApi _valContentApi;
+        private readonly ValRankedApi _valRankedApi;
         private readonly ValStatusApi _valStatusApi;
         public IAccountApi Account => _accountApi;
         public IChampionApi Champion => _championApi;
@@ -122,6 +127,7 @@ namespace BlossomiShymae.RiotBlossom.Api
         public ITftStatusApi TftStatus => _tftStatusApi;
         public ITftSummonerApi TftSummoner => _tftSummonerApi;
         public IValContentApi ValContent => _valContentApi;
+        public IValRankedApi ValRanked => _valRankedApi;
         public IValStatusApi ValStatus => _valStatusApi;
 
         public RiotApi(RiotHttpClient riotHttpClient)
@@ -144,6 +150,7 @@ namespace BlossomiShymae.RiotBlossom.Api
             _tftStatusApi = new(riotHttpClient);
             _tftSummonerApi = new(riotHttpClient);
             _valContentApi = new(riotHttpClient);
+            _valRankedApi = new(riotHttpClient);
             _valStatusApi = new(riotHttpClient);
         }
     }

--- a/BlossomiShymae.RiotBlossom/Core/ValRegionMapper.cs
+++ b/BlossomiShymae.RiotBlossom/Core/ValRegionMapper.cs
@@ -1,0 +1,39 @@
+﻿using BlossomiShymae.RiotBlossom.Type;
+using System.Collections.Immutable;
+
+namespace BlossomiShymae.RiotBlossom.Core
+{
+    /// <summary>
+    /// A mapper class for the <see cref="ValRegion"/> enum. Used for obtaining the raw value.
+    /// </summary>
+    public static class ValRegionMapper
+    {
+        private static readonly ImmutableDictionary<ValRegion, string> s_regionByRoute =
+            new Dictionary<ValRegion, string>
+            {
+                { ValRegion.NorthAmerica, "na" },
+                { ValRegion.Brazil, "br" },
+                { ValRegion.Korea, "kr" },
+                { ValRegion.AsiaPacific, "ap" },
+                { ValRegion.LatinAmerica, "latam" },
+                { ValRegion.Europe, "eu" }
+            }.ToImmutableDictionary();
+
+        public static string GetId(ValRegion valRegion)
+        {
+            string? region = s_regionByRoute.GetValueOrDefault(valRegion);
+            return region ?? throw new NotImplementedException($"VALORANT region for regional route {valRegion} not implemented");
+        }
+
+        public static ValRegion FromId(string id)
+        {
+            var kvpList = s_regionByRoute.ToList();
+            foreach (var kv in kvpList)
+            {
+                if (kv.Value == id)
+                    return kv.Key;
+            }
+            throw new NotImplementedException($"Could not find VALORANT region for id {id}");
+        }
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Core/ValRegionMapper.cs
+++ b/BlossomiShymae.RiotBlossom/Core/ValRegionMapper.cs
@@ -33,7 +33,7 @@ namespace BlossomiShymae.RiotBlossom.Core
                 if (kv.Value == id)
                     return kv.Key;
             }
-            throw new NotImplementedException($"Could not find VALORANT region for id {id}");
+            throw new InvalidOperationException($"Could not find VALORANT region for id {id}");
         }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ActDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ActDto.cs
@@ -1,0 +1,10 @@
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
+{
+    public record ActDto
+    {
+        public string Name { get; init; } = default!;
+        public LocalizedNamesDto? LocalizedNames { get; init; }
+        public string Id { get; init; } = default!;
+        public bool IsActive { get; init; }
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ActDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ActDto.cs
@@ -3,6 +3,9 @@
     public record ActDto
     {
         public string Name { get; init; } = default!;
+        /// <summary>
+        /// This is excluded from respone when a locale is set.
+        /// </summary>
         public LocalizedNamesDto? LocalizedNames { get; init; }
         public string Id { get; init; } = default!;
         public bool IsActive { get; init; }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ContentDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ContentDto.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Immutable;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
+{
+    public record ContentDto
+    {
+        public string Version { get; init; } = default!;
+        public ImmutableList<ContentItemDto> Characters { get; init; } = ImmutableList<ContentItemDto>.Empty;
+        public ImmutableList<ContentItemDto> Maps { get; init; } = ImmutableList<ContentItemDto>.Empty;
+        public ImmutableList<ContentItemDto> Chromas { get; init; } = ImmutableList<ContentItemDto>.Empty;
+        public ImmutableList<ContentItemDto> Skins { get; init; } = ImmutableList<ContentItemDto>.Empty;
+        public ImmutableList<ContentItemDto> SkinLevels { get; init; } = ImmutableList<ContentItemDto>.Empty;
+        public ImmutableList<ContentItemDto> Equips { get; init; } = ImmutableList<ContentItemDto>.Empty;
+        public ImmutableList<ContentItemDto> GameModes { get; init; } = ImmutableList<ContentItemDto>.Empty;
+        public ImmutableList<ContentItemDto> Sprays { get; init; } = ImmutableList<ContentItemDto>.Empty;
+        public ImmutableList<ContentItemDto> SprayLevels { get; init; } = ImmutableList<ContentItemDto>.Empty;
+        public ImmutableList<ContentItemDto> Charms { get; init; } = ImmutableList<ContentItemDto>.Empty;
+        public ImmutableList<ContentItemDto> CharmLevels { get; init; } = ImmutableList<ContentItemDto>.Empty;
+        public ImmutableList<ContentItemDto> PlayerCards { get; init; } = ImmutableList<ContentItemDto>.Empty;
+        public ImmutableList<ContentItemDto> PlayerTitles { get; init; } = ImmutableList<ContentItemDto>.Empty;
+        public ImmutableList<ActDto> Acts { get; init; } = ImmutableList<ActDto>.Empty;
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ContentItemDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ContentItemDto.cs
@@ -1,0 +1,17 @@
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
+{
+    public record ContentItemDto
+    {
+        public string Name { get; init; } = default!;
+        /// <summary>
+        /// This is excluded when a locale is set.
+        /// </summary>
+        public LocalizedNamesDto? LocalizedNames { get; init; }
+        public string Id { get; init; } = default!;
+        public string AssetName { get; init; } = default!;
+        /// <summary>
+        /// This is only included for maps and game modes.
+        /// </summary>
+        public string AssetPath { get; init; } = default!;
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/LocalizedNamesDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/LocalizedNamesDto.cs
@@ -1,0 +1,49 @@
+﻿using System.Text.Json.Serialization;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
+{
+    public record LocalizedNamesDto
+    {
+        [JsonPropertyName("ar-AE")]
+        public string ArabicUAE { get; init; } = default!;
+        [JsonPropertyName("de-DE")]
+        public string GermanGermany { get; init; } = default!;
+        [JsonPropertyName("en-GB")]
+        public string EnglishUnitedKingdom { get; init; } = default!;
+        [JsonPropertyName("en-US")]
+        public string EnglishUnitedStates { get; init; } = default!;
+        [JsonPropertyName("es-ES")]
+        public string SpanishSpain { get; init; } = default!;
+        [JsonPropertyName("es-MX")]
+        public string SpanishMexico { get; init; } = default!;
+        [JsonPropertyName("fr-FR")]
+        public string FrenchFrance { get; init; } = default!;
+        [JsonPropertyName("id-ID")]
+        public string IndonesianIndonesia { get; init; } = default!;
+        [JsonPropertyName("it-IT")]
+        public string ItalianItaly { get; init; } = default!;
+        /// <summary>
+        /// Yaa!
+        /// </summary>
+        [JsonPropertyName("ja-JP")]
+        public string JapaneseJapan { get; init; } = default!;
+        [JsonPropertyName("ko-KR")]
+        public string KoreanKorea { get; init; } = default!;
+        [JsonPropertyName("pl-PL")]
+        public string PolishPoland { get; init; } = default!;
+        [JsonPropertyName("pt-BR")]
+        public string PortugueseBrazil { get; init; } = default!;
+        [JsonPropertyName("ru-RU")]
+        public string RussianRussia { get; init; } = default!;
+        [JsonPropertyName("th-TH")]
+        public string ThaiThailand { get; init; } = default!;
+        [JsonPropertyName("tr-TR")]
+        public string TurkishTurkey { get; init; } = default!;
+        [JsonPropertyName("vi-VN")]
+        public string VietnameseVietnam { get; init; } = default!;
+        [JsonPropertyName("zh-CN")]
+        public string ChineseSimplified { get; init; } = default!;
+        [JsonPropertyName("zh-TW")]
+        public string ChineseTaiwan { get; init; } = default!;
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/AbilityCastsDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/AbilityCastsDto.cs
@@ -1,0 +1,10 @@
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record AbilityCastsDto
+    {
+        public int GrenadeCasts { get; init; }
+        public int Ability1Casts { get; init; }
+        public int Ability2Casts { get; init; }
+        public int UltimateCasts { get; init; }
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/AbilityDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/AbilityDto.cs
@@ -1,0 +1,10 @@
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record AbilityDto
+    {
+        public string GrenadeEffects { get; init; } = default!;
+        public string Ability1Effects { get; init; } = default!;
+        public string Ability2Effects { get; init; } = default!;
+        public string UltimateEffects { get; init; } = default!;
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/CoachDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/CoachDto.cs
@@ -1,0 +1,8 @@
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record CoachDto
+    {
+        public string Puuid { get; init; } = default!;
+        public string TeamId { get; init; } = default!;
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/DamageDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/DamageDto.cs
@@ -1,0 +1,14 @@
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record DamageDto
+    {
+        /// <summary>
+        /// The PUUID of affected player.
+        /// </summary>
+        public string Receiver { get; init; } = default!;
+        public int Damage { get; init; }
+        public int Legshots { get; init; }
+        public int Bodyshots { get; init; }
+        public int Headshots { get; init; }
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/EconomyDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/EconomyDto.cs
@@ -1,0 +1,11 @@
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record EconomyDto
+    {
+        public int LoadoutValue { get; init; }
+        public string Weapon { get; init; } = default!;
+        public string Armor { get; init; } = default!;
+        public int Remaining { get; init; }
+        public int Spent { get; init; }
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/FinishingDamageDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/FinishingDamageDto.cs
@@ -1,0 +1,9 @@
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record FinishingDamageDto
+    {
+        public string DamageType { get; init; } = default!;
+        public string DamageItem { get; init; } = default!;
+        public bool IsSecondaryFireMode { get; init; }
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/KillDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/KillDto.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Immutable;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record KillDto
+    {
+        public int TimeSinceGameStartMillis { get; init; }
+        public int TimeSinceRoundStartMillis { get; init; }
+        /// <summary>
+        /// The PUUID of killer.
+        /// </summary>
+        public string Killer { get; init; } = default!;
+        /// <summary>
+        /// The PUUID of victim.
+        /// </summary>
+        public string Victim { get; init; } = default!;
+        public LocationDto VictimLocation { get; init; } = new();
+        /// <summary>
+        /// The list of PUUIDs.
+        /// </summary>
+        public ImmutableList<string> Assistants { get; init; } = ImmutableList<string>.Empty;
+        public ImmutableList<PlayerLocationsDto> PlayerLocations { get; init; } = ImmutableList<PlayerLocationsDto>.Empty;
+        public FinishingDamageDto FinishingDamage { get; init; } = new();
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/LocationDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/LocationDto.cs
@@ -1,0 +1,8 @@
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record LocationDto
+    {
+        public int X { get; init; }
+        public int Y { get; init; }
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchDto.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Immutable;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record MatchDto
+    {
+        public MatchInfoDto MatchInfo { get; init; } = new();
+        public ImmutableList<PlayerDto> Players { get; init; } = ImmutableList<PlayerDto>.Empty;
+        public ImmutableList<CoachDto> Coaches { get; init; } = ImmutableList<CoachDto>.Empty;
+        public ImmutableList<TeamDto> Teams { get; init; } = ImmutableList<TeamDto>.Empty;
+        public ImmutableList<RoundResultDto> RoundResults { get; init; } = ImmutableList<RoundResultDto>.Empty;
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchInfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchInfoDto.cs
@@ -1,12 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    internal class MatchInfoDto
+    public record MatchInfoDto
     {
+        public string MatchId { get; init; } = default!;
+        public string MapId { get; init; } = default!;
+        public int GameLengthMillis { get; init; }
+        public long GameStartMillis { get; init; }
+        public string ProvisioningFlowId { get; init; } = default!;
+        public bool IsCompleted { get; init; }
+        public string CustomGameName { get; init; } = default!;
+        public string QueueId { get; init; } = default!;
+        public string GameMode { get; init; } = default!;
+        public bool IsRanked { get; init; }
+        public string SeasonId { get; init; } = default!;
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchInfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchInfoDto.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    internal class MatchInfoDto
+    {
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchlistDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchlistDto.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Immutable;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record MatchlistDto
+    {
+        public string Puuid { get; init; } = default!;
+        public ImmutableList<MatchlistEntryDto> History { get; init; } = ImmutableList<MatchlistEntryDto>.Empty;
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchlistEntryDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchlistEntryDto.cs
@@ -1,0 +1,9 @@
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record MatchlistEntryDto
+    {
+        public string MatchId { get; init; } = default!;
+        public long GameStartTimeMillis { get; init; }
+        public string TeamId { get; init; } = default!;
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerDto.cs
@@ -1,0 +1,16 @@
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record PlayerDto
+    {
+        public string Puuid { get; init; } = default!;
+        public string GameName { get; init; } = default!;
+        public string TagLine { get; init; } = default!;
+        public string TeamId { get; init; } = default!;
+        public string PartyId { get; init; } = default!;
+        public string CharacterId { get; init; } = default!;
+        public PlayerStatsDto Stats { get; init; } = new();
+        public int CompetitiveTier { get; init; }
+        public string PlayerCard { get; init; } = default!;
+        public string PlayerTitle { get; init; } = default!;
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerLocationsDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerLocationsDto.cs
@@ -1,0 +1,9 @@
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record PlayerLocationsDto
+    {
+        public string Puuid { get; init; } = default!;
+        public float ViewRadians { get; init; }
+        public LocationDto Location { get; init; } = new();
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerRoundStatsDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerRoundStatsDto.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Immutable;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record PlayerRoundStatsDto
+    {
+        public string Puuid { get; init; } = default!;
+        public ImmutableList<KillDto> Kills { get; init; } = ImmutableList<KillDto>.Empty;
+        public ImmutableList<DamageDto> Damage { get; init; } = ImmutableList<DamageDto>.Empty;
+        public int Score { get; init; }
+        public EconomyDto Economy { get; init; } = new();
+        public AbilityDto Ability { get; init; } = new();
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerStatsDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerStatsDto.cs
@@ -1,0 +1,13 @@
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record PlayerStatsDto
+    {
+        public int Score { get; init; }
+        public int RoundsPlayed { get; init; }
+        public int Kills { get; init; }
+        public int Deaths { get; init; }
+        public int Assists { get; init; }
+        public int PlaytimeMillis { get; init; }
+        public AbilityCastsDto AbilityCasts { get; init; } = new();
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/RecentMatchesDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/RecentMatchesDto.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Immutable;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record RecentMatchesDto
+    {
+        public long CurrentTime { get; init; }
+        public ImmutableList<string> MatchIds { get; init; } = ImmutableList<string>.Empty;
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/RoundResultDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/RoundResultDto.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Immutable;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record RoundResultDto
+    {
+        public int RoundNum { get; init; }
+        public string RoundResult { get; init; } = default!;
+        public string RoundCeremony { get; init; } = default!;
+        public string WinningTeam { get; init; } = default!;
+        public string BombPlanter { get; init; } = default!;
+        public string BombDefuser { get; init; } = default!;
+        public int PlantRoundTime { get; init; }
+        public ImmutableList<PlayerLocationsDto> PlantPlayerLocations { get; init; } = ImmutableList<PlayerLocationsDto>.Empty;
+        public LocationDto PlantLocation { get; init; } = new();
+        public string PlantSite { get; init; } = default!;
+        public int DefuseRoundTime { get; init; }
+        public ImmutableList<PlayerLocationsDto> DefusePlayerLocations { get; init; } = ImmutableList<PlayerLocationsDto>.Empty;
+        public LocationDto DefuseLocation { get; init; } = new();
+        public ImmutableList<PlayerRoundStatsDto> PlayerStats { get; init; } = ImmutableList<PlayerRoundStatsDto>.Empty;
+        public string RoundResultCode { get; init; } = default!;
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/TeamDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/TeamDto.cs
@@ -1,0 +1,26 @@
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+{
+    public record TeamDto
+    {
+        /// <summary>
+        /// The arbitrary string, being Red and Blue in bomb modes, the PUUID of the player in deathmatch.
+        /// </summary>
+        public string TeamId { get; init; } = default!;
+        /// <summary>
+        /// Whether the team has won the game.
+        /// </summary>
+        public bool Won { get; init; }
+        /// <summary>
+        /// The amount of rounds played.
+        /// </summary>
+        public int RoundsPlayed { get; init; }
+        /// <summary>
+        /// The amount of rounds the team won.
+        /// </summary>
+        public int RoundsWon { get; init; }
+        /// <summary>
+        /// The team points scored. Number of kills in deathmatch.
+        /// </summary>
+        public int NumPoints { get; init; }
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValRanked/LeaderboardDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValRanked/LeaderboardDto.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Immutable;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValRanked
+{
+    public record LeaderboardDto
+    {
+        /// <summary>
+        /// The shard for the given leaderboard.
+        /// </summary>
+        public string Shard { get; init; } = default!;
+        /// <summary>
+        /// The act ID for the given leaderboard.
+        /// </summary>
+        public string ActId { get; init; } = default!;
+        /// <summary>
+        /// The total number of players in the given leaderboard.
+        /// </summary>
+        public long TotalPlayers { get; init; }
+        /// <summary>
+        /// The list of participating players.
+        /// </summary>
+        public ImmutableList<PlayerDto> Players { get; init; } = ImmutableList<PlayerDto>.Empty;
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValRanked/PlayerDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValRanked/PlayerDto.cs
@@ -1,0 +1,21 @@
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValRanked
+{
+    public record PlayerDto
+    {
+        /// <summary>
+        /// The player UUID. May be omitted if player is anonymized.
+        /// </summary>
+        public string? Puuid { get; init; }
+        /// <summary>
+        /// The game name of player. May be omitted if player is anonymized.
+        /// </summary>
+        public string? GameName { get; init; }
+        /// <summary>
+        /// The tag line of player. May be omitted if player is anonymized.
+        /// </summary>
+        public string? TagLine { get; init; }
+        public long LeaderboardRank { get; init; }
+        public long RankedRating { get; init; }
+        public long NumberOfWins { get; init; }
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Type/ValRegion.cs
+++ b/BlossomiShymae.RiotBlossom/Type/ValRegion.cs
@@ -1,0 +1,15 @@
+﻿namespace BlossomiShymae.RiotBlossom.Type
+{
+    /// <summary>
+    /// <para>An enum that serves as a representation of regional routing values for VALORANT.</para>
+    /// </summary>
+    public enum ValRegion
+    {
+        NorthAmerica,
+        AsiaPacific,
+        Brazil,
+        Korea,
+        Europe,
+        LatinAmerica
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Type/ValRegion.cs
+++ b/BlossomiShymae.RiotBlossom/Type/ValRegion.cs
@@ -1,7 +1,10 @@
-﻿namespace BlossomiShymae.RiotBlossom.Type
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Type
 {
     /// <summary>
     /// <para>An enum that serves as a representation of regional routing values for VALORANT.</para>
+    /// <para>See <see cref="ValRegionMapper"/></para>
     /// </summary>
     public enum ValRegion
     {

--- a/BlossomiShymae.RiotBlossomTests/Api/Riot/ValContentApiTests.cs
+++ b/BlossomiShymae.RiotBlossomTests/Api/Riot/ValContentApiTests.cs
@@ -1,0 +1,31 @@
+﻿using BlossomiShymae.RiotBlossom.Core;
+using BlossomiShymae.RiotBlossom.Dto.Riot.ValContent;
+using BlossomiShymae.RiotBlossom.Type;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BlossomiShymae.RiotBlossomTests.Api.Riot
+{
+    [TestClass()]
+    public class ValContentApiTests
+    {
+        [TestMethod()]
+        public async Task Api_ByDefault_ShouldReturnContentDto()
+        {
+            IRiotBlossomClient client = StubConfig.Client;
+
+            ContentDto dto = await client.Riot.ValContent.GetContentAsync(ValRegion.NorthAmerica);
+
+            Assert.IsInstanceOfType(dto, typeof(ContentDto));
+        }
+
+        [TestMethod()]
+        public async Task Api_WithLocale_ShouldReturnContentDto()
+        {
+            IRiotBlossomClient client = StubConfig.Client;
+
+            ContentDto dto = await client.Riot.ValContent.GetContentByLocaleAsync(ValRegion.NorthAmerica, "en-US");
+
+            Assert.IsTrue(dto.Characters.First().LocalizedNames == null);
+        }
+    }
+}

--- a/BlossomiShymae.RiotBlossomTests/Api/Riot/ValRankedApiTests.cs
+++ b/BlossomiShymae.RiotBlossomTests/Api/Riot/ValRankedApiTests.cs
@@ -1,0 +1,33 @@
+﻿using BlossomiShymae.RiotBlossom.Core;
+using BlossomiShymae.RiotBlossom.Dto.Riot.ValRanked;
+using BlossomiShymae.RiotBlossom.Type;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BlossomiShymae.RiotBlossomTests.Api.Riot
+{
+    [TestClass()]
+    public class ValRankedApiTests
+    {
+        public static readonly string ActId = "2de5423b-4aad-02ad-8d9b-c0a931958861";
+
+        [TestMethod()]
+        public async Task Api_WithActId_ShouldReturnLeaderboardDto()
+        {
+            IRiotBlossomClient client = StubConfig.Client;
+
+            LeaderboardDto dto = await client.Riot.ValRanked.GetLeaderboardByActIdAsync(ValRegion.NorthAmerica, ActId);
+
+            Assert.IsInstanceOfType(dto, typeof(LeaderboardDto));
+        }
+
+        [TestMethod()]
+        public async Task Api_WithActIdAndOptions_ShouldReturnLeaderboardDto()
+        {
+            IRiotBlossomClient client = StubConfig.Client;
+
+            LeaderboardDto dto = await client.Riot.ValRanked.GetLeaderboardByActIdAsync(ValRegion.NorthAmerica, ActId, new() { Size = 100, StartIndex = 0 });
+
+            Assert.IsTrue(dto.Players.Count <= 100);
+        }
+    }
+}

--- a/BlossomiShymae.RiotBlossomTests/Api/Riot/ValStatusApiTests.cs
+++ b/BlossomiShymae.RiotBlossomTests/Api/Riot/ValStatusApiTests.cs
@@ -1,0 +1,21 @@
+﻿using BlossomiShymae.RiotBlossom.Core;
+using BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus;
+using BlossomiShymae.RiotBlossom.Type;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BlossomiShymae.RiotBlossomTests.Api.Riot
+{
+    [TestClass()]
+    public class ValStatusApiTests
+    {
+        [TestMethod()]
+        public async Task Api_ByDefault_ShouldReturnPlatformDataDto()
+        {
+            IRiotBlossomClient client = StubConfig.Client;
+
+            PlatformDataDto dto = await client.Riot.ValStatus.GetPlatformStatusAsync(ValRegion.NorthAmerica);
+
+            Assert.IsInstanceOfType(dto, typeof(PlatformDataDto));
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Made with [contrib.rocks](https://contrib.rocks).
     - League of Legends
     - Teamfight Tactics
     - Legends of Runeterra
+    - VALORANT
 - DataDragon support
 - CommunityDragon support
 - Love (੭ु ›ω‹ )੭ु⁾⁾♡
@@ -96,11 +97,11 @@ dotnet add package BlossomiShymae.RiotBlossom
 - ✅ Lor-Ranked-v1
 - ✅ Lor-Status-v1
 
-### Valorant
-- ➖ Val-Content-v1
-- ➖ Val-Match-v1
-- ➖ Val-Ranked-v1
-- ➖ Val-Status-v1
+### VALORANT
+- ✅ Val-Content-v1
+- ✅ Val-Match-v1 ("Unsure if this works as I do not have access to this endpoint for testing ˚‧º·(˚ ˃̣̣̥⌓˂̣̣̥ )‧º·˚" - BlossomiShymae)
+- ✅ Val-Ranked-v1
+- ✅ Val-Status-v1
 
 ## DataDragon
 - ✅ Champions (`championFull.json`)
@@ -451,6 +452,7 @@ RiotBlossom uses types to represent named values used for the Riot Games API.
 - `Platform`
 - `Region`
 - `RiotHeader`
+- `ValRegion`
 
 ## ChallengeLevel
 Represents the possible challenge levels for `lol-challenges-v1`.
@@ -483,6 +485,9 @@ Represents the available regional routing values used for the Riot API (League o
 ## RiotHeader
 A structure of string constants used for [Riot rate limiting headers](https://hextechdocs.dev/rate-limiting/).
 
+## ValRegion
+Represents the available regional routing values used for VALORANT.
+
 # Utilities
 Mappers and converters are also included to get the raw or converted values of the aformentioned types. 
 These are used internally for projecting values when making requests to the Riot APIs.
@@ -494,6 +499,7 @@ These are used internally for projecting values when making requests to the Riot
 - `PlatformMapper`
 - `PlatformToRegionConverter`
 - `RegionMapper`
+- `ValRegionMapper`
 
 # Data transfer objects (DTO)
 RiotBlossom uses simple objects with no behavior for JSON deserialization. These objects are strongly typed and are 


### PR DESCRIPTION
Resolves #3 !

# VALORANT support

- Add `val-content-v1` endpoint via `IValContent`, `ValContent`
- Add `val-match-v1` endpoint via `IValMatch`, `ValMatch`
- Add `val-ranked-v1` endpoint via `IValRanked`, `ValRanked`
- Add `val-status-v1` endpoint via `IValStatus`, `ValStatus`

## Classes

- Add `ValRegion` enum and `ValRegionMapper` mapper
- Add new records under `Dto.Riot` namespace
  - `ValContent`
    - `ActDto`
    - `ContentDto`
    - `ContentItemDto`
    - `LocalizedNamesDto`
  - `ValMatch`
    - `AbilityCastsDto`
    - `AbilityDto`
    - `CoachDto`
    - `DamageDto`
    - `EconomyDto`
    - `FinishingDamageDto`
    - `KillDto`
    - `LocationDto`
    - `MatchDto`
    - `MatchInfoDto`
    - `MatchlistDto`
    - `MatchlistEntryDto`
    - `PlayerDto`
    - `PlayerLocationsDto`
    - `PlayerRoundStatsDto`
    - `PlayerStatsDto`
    - `RecentMatchesDto`
    - `RoundResultDto`
    - `TeamDto`
  - `ValRanked`
    - `LeaderboardDto`
    - `PlayerDto`
