### PR TITLE
Update `ToString` methods for objects in `Dto` namespace

### DIFF
--- a/BlossomiShymae.RiotBlossom/Core/PrettyPrinter.cs
+++ b/BlossomiShymae.RiotBlossom/Core/PrettyPrinter.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Text;
+using System.Text.Json;
 
 namespace BlossomiShymae.RiotBlossom.Core
 {
@@ -20,7 +21,27 @@ namespace BlossomiShymae.RiotBlossom.Core
         /// <exception cref="NotSupportedException"></exception>
         /// <param name="obj"></param>
         /// <returns></returns>
-        public static string GetString(object obj)
-            => JsonSerializer.Serialize(obj, options: s_options);
+        public static string GetString<T>(T obj) where T : notnull
+        {
+            StringBuilder sb = new();
+            System.Type type = typeof(T);
+            sb.Append(type.Name);
+            if (type.IsGenericType)
+            {
+                sb.Append('[');
+                System.Type[] typeArguments = type.GetGenericArguments();
+                for (int i = 0; i < typeArguments.Length; i++)
+                {
+                    sb.Append(typeArguments[i].Name);
+                    if (i != typeArguments.Length - 1)
+                        sb.Append(new char[] { ',', ' ' });
+                }
+                sb.Append(']');
+            }
+            sb.Append(' ');
+            sb.Append(JsonSerializer.Serialize((object)obj, options: s_options));
+
+            return sb.ToString();
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Core/PrettyPrinter.cs
+++ b/BlossomiShymae.RiotBlossom/Core/PrettyPrinter.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 namespace BlossomiShymae.RiotBlossom.Core
 {
     /// <summary>
-    /// A helper class used for prettifying strings.
+    /// A helper class used for getting pretty printed strings.
     /// </summary>
     public static class PrettyPrinter
     {

--- a/BlossomiShymae.RiotBlossom/Core/PrettyPrinter.cs
+++ b/BlossomiShymae.RiotBlossom/Core/PrettyPrinter.cs
@@ -1,0 +1,26 @@
+﻿using System.Text.Json;
+
+namespace BlossomiShymae.RiotBlossom.Core
+{
+    /// <summary>
+    /// A helper class used for prettifying strings.
+    /// </summary>
+    public static class PrettyPrinter
+    {
+        private static readonly JsonSerializerOptions s_options = new()
+        {
+            WriteIndented = true,
+            AllowTrailingCommas = true,
+            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        };
+
+        /// <summary>
+        /// <para>Get the pretty string of object, hehe!</para>
+        /// </summary>
+        /// <exception cref="NotSupportedException"></exception>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public static string GetString(object obj)
+            => JsonSerializer.Serialize(obj, options: s_options);
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Core/PrettyPrinter.cs
+++ b/BlossomiShymae.RiotBlossom/Core/PrettyPrinter.cs
@@ -17,6 +17,7 @@ namespace BlossomiShymae.RiotBlossom.Core
 
         /// <summary>
         /// <para>Get the pretty string of object, hehe!</para>
+        /// <para>Note: Field names will be printed into camel case or into JsonPropertyName attribute.</para>
         /// </summary>
         /// <exception cref="NotSupportedException"></exception>
         /// <param name="obj"></param>

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Champion.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Champion.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
@@ -23,5 +24,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
         public ImmutableList<Skin> Skins { get; init; } = ImmutableList<Skin>.Empty;
         public Passive Passive { get; init; } = new();
         public ImmutableList<Spell> Spells { get; init; } = ImmutableList<Spell>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Chroma.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Chroma.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
@@ -13,5 +14,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
         public ImmutableList<string> Colors { get; init; } = ImmutableList<string>.Empty;
         public ImmutableList<ChromaDescription> Descriptions { get; init; } = ImmutableList<ChromaDescription>.Empty;
         public ImmutableList<ChromaRarity> Rarities { get; init; } = ImmutableList<ChromaRarity>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/ChromaDescription.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/ChromaDescription.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -7,5 +9,10 @@
     {
         public string Region { get; init; } = default!;
         public string Description { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/ChromaRarity.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/ChromaRarity.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -7,5 +9,10 @@
     {
         public string Region { get; init; } = default!;
         public int Rarity { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Passive.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Passive.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -10,5 +12,10 @@
         public string AbilityVideoPath { get; init; } = default!;
         public string AbilityVideoImagePath { get; init; } = default!;
         public string Description { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/PlaystyleInfo.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/PlaystyleInfo.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -10,5 +12,10 @@
         public int CrowdControl { get; init; }
         public int Mobility { get; init; }
         public int Utility { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Skin.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Skin.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
@@ -27,5 +28,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
         public string? RarityGemPath { get; init; }
         public ImmutableList<SkinLine>? SkinLines { get; init; }
         public string Description { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/SkinLine.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/SkinLine.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -6,5 +8,10 @@
     public record SkinLine
     {
         public int Id { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Spell.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Spell.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
@@ -22,5 +23,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
         public object EffectAmounts { get; init; } = default!;
         public object Ammo { get; init; } = default!;
         public int MaxLevel { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/TacticalInfo.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/TacticalInfo.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -8,5 +10,10 @@
         public int Style { get; init; }
         public int Difficulty { get; init; }
         public string DamageType { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Item/Item.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Item/Item.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Item
 {
@@ -25,5 +26,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Item
         public int Price { get; init; }
         public int PriceTotal { get; init; }
         public string IconPath { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Perk/PerkRune.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Perk/PerkRune.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Perk
 {
@@ -17,5 +18,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Perk
         public string IconPath { get; init; } = default!;
         public ImmutableList<string> EndOfGameStatDescs { get; init; } = ImmutableList<string>.Empty;
         public ImmutableDictionary<string, double> RecommendationDescriptorAttributes { get; init; } = ImmutableDictionary<string, double>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Champion.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Champion.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
 {
@@ -24,5 +25,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
         public ImmutableList<Spell> Spells { get; init; } = ImmutableList<Spell>.Empty;
         public Passive Passive { get; init; } = new();
         public object? Recommended { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Image.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Image.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -12,5 +14,10 @@
         public int Y { get; init; }
         public int W { get; init; }
         public int H { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Info.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Info.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -9,5 +11,10 @@
         public int Defense { get; init; }
         public int Magic { get; init; }
         public int Difficulty { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Leveltip.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Leveltip.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
 {
@@ -9,5 +10,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
     {
         public ImmutableList<string> Label { get; init; } = ImmutableList<string>.Empty;
         public ImmutableList<string> Effect { get; init; } = ImmutableList<string>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Passive.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Passive.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -8,5 +10,10 @@
         public string Name { get; init; } = default!;
         public string Description { get; init; } = default!;
         public Image Image { get; init; } = new();
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Skin.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Skin.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -9,5 +11,10 @@
         public int Num { get; init; }
         public string Name { get; init; } = default!;
         public bool Chromas { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Spell.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Spell.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
 {
@@ -27,5 +28,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
         public string RangeBurn { get; init; } = default!;
         public Image Image { get; init; } = new();
         public string Resource { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Stats.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Stats.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -25,5 +27,10 @@
         public double Attackdamageperlevel { get; init; }
         public double Attackspeedperlevel { get; init; }
         public double Attackspeed { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Item/Gold.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Item/Gold.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Item
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Item
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -9,5 +11,10 @@
         public int Total { get; init; }
         public int Sell { get; init; }
         public bool Purchasable { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Item/Image.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Item/Image.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Item
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Item
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -12,5 +14,10 @@
         public int Y { get; init; }
         public int W { get; init; }
         public int H { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Item/Item.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Item/Item.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Item
 {
@@ -28,5 +29,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Item
         public ImmutableDictionary<string, double> Stats { get; init; } = ImmutableDictionary<string, double>.Empty;
         public ImmutableList<string> Tags { get; init; } = ImmutableList<string>.Empty;
         public ImmutableDictionary<int, bool> Maps { get; init; } = ImmutableDictionary<int, bool>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Item/Rune.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Item/Rune.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Item
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Item
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -8,5 +10,10 @@
         public bool IsRune { get; init; }
         public int Tier { get; init; }
         public string Type { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Perk/PerkRune.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Perk/PerkRune.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Perk
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Perk
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -11,5 +13,10 @@
         public string Name { get; init; } = default!;
         public string ShortDesc { get; init; } = default!;
         public string LongDesc { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Perk/PerkStyle.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Perk/PerkStyle.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Perk
 {
@@ -12,5 +13,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Perk
         public string Icon { get; init; } = default!;
         public string Name { get; init; } = default!;
         public ImmutableList<Slot> Slots { get; init; } = ImmutableList<Slot>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Perk/Slot.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Perk/Slot.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Perk
 {
@@ -8,5 +9,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Perk
     public record Slot
     {
         public ImmutableList<PerkRune> Runes { get; init; } = ImmutableList<PerkRune>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Account/AccountDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Account/AccountDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Account
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Account
 {
     public record AccountDto
     {
@@ -14,5 +16,10 @@
         /// The Riot tag line associated with account. May be excluded from response if account does not have it.
         /// </summary>
         public string TagLine { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Champion/ChampionInfo.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Champion/ChampionInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Champion
 {
@@ -17,5 +18,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Champion
         /// The current free champion rotation pool.
         /// </summary>
         public ImmutableList<int> FreeChampionIds { get; init; } = ImmutableList<int>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ChampionMastery/ChampionMasteryDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ChampionMastery/ChampionMasteryDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ChampionMastery
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ChampionMastery
 {
     public record ChampionMasteryDto
     {
@@ -39,5 +41,10 @@
         /// The tokens earned for champion at current level. Resets to zero when <see cref="ChampionLevel"/> advances.
         /// </summary>
         public int TokensEarned { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Clash/PlayerDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Clash/PlayerDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
 {
     public record PlayerDto
     {
@@ -18,5 +20,10 @@
         /// The assigned role ('CAPTAIN', 'MEMBER').
         /// </summary>
         public string Role { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Clash/TeamDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Clash/TeamDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
 {
@@ -36,5 +37,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
         /// The current team roster.
         /// </summary>
         public ImmutableList<PlayerDto> Players { get; init; } = ImmutableList<PlayerDto>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Clash/TournamentDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Clash/TournamentDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
 {
@@ -24,5 +25,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
         /// The spanning date the tournament will take place on.
         /// </summary>
         public ImmutableList<TournamentPhaseDto> Schedule { get; init; } = ImmutableList<TournamentPhaseDto>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Clash/TournamentPhaseDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Clash/TournamentPhaseDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
 {
     public record TournamentPhaseDto
     {
@@ -18,5 +20,10 @@
         /// Whether the tournament phase will occur for totes' whatever reason. :3
         /// </summary>
         public bool Cancelled { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/League/LeagueEntryDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/League/LeagueEntryDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
 {
     public record LeagueEntryDto
     {
@@ -58,5 +60,10 @@
         /// The current miniseries (rank promotions) the player is involved in.
         /// </summary>
         public MiniSeriesDto? MiniSeries { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/League/LeagueItemDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/League/LeagueItemDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
 {
     public record LeagueItemDto
     {
@@ -46,5 +48,10 @@
         /// The player encrypted summoner ID.
         /// </summary>
         public string SummonerId { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/League/LeagueListDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/League/LeagueListDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
 {
@@ -24,5 +25,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
         /// The queue type the league is for e.g. "RANKED_SOLO_5x5".
         /// </summary>
         public string Queue { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/League/MiniSeriesDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/League/MiniSeriesDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
 {
     public record MiniSeriesDto
     {
@@ -33,5 +35,10 @@
         /// The game wins for miniseries.
         /// </summary>
         public int Wins { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/ApexPlayerInfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/ApexPlayerInfoDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
 {
     public record ApexPlayerInfoDto
     {
@@ -14,5 +16,10 @@
         /// The leaderboard position of apex player.
         /// </summary>
         public long Position { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/ChallengeConfigInfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/ChallengeConfigInfoDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
 {
@@ -37,5 +38,9 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
         /// </summary>
         public ImmutableDictionary<string, double> Thresholds { get; init; } = ImmutableDictionary<string, double>.Empty;
 
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/ChallengeInfo.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/ChallengeInfo.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -10,5 +12,10 @@
         public string Level { get; init; } = default!;
         public double Value { get; init; }
         public long AchievedTime { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/ChallengePoints.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/ChallengePoints.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -9,5 +11,10 @@
         public double Current { get; init; }
         public double Max { get; init; }
         public double Percentile { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/LocalizedName.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/LocalizedName.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
 {
     public record LocalizedName
     {
@@ -14,5 +16,10 @@
         /// The localized brief description of challenge.
         /// </summary>
         public string ShortDescription { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/PlayerClientPreferences.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/PlayerClientPreferences.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
 {
@@ -10,5 +11,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
         public string BannerAccent { get; init; } = default!;
         public string Title { get; init; } = default!;
         public ImmutableList<int> ChallengeIds { get; init; } = ImmutableList<int>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/PlayerInfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/PlayerInfoDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
 {
@@ -20,5 +21,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
         /// The map of challenge point information by category e.g. "TEAMWORK", "EXPERTISE", "IMAGINATION", "VETERANCY", "COLLECTION".
         /// </summary>
         public ImmutableDictionary<string, ChallengePoints> CategoryPoints { get; init; } = ImmutableDictionary<string, ChallengePoints>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolStatus/ContentDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolStatus/ContentDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus
 {
     public record ContentDto
     {
@@ -10,5 +12,10 @@
         /// The text content for incident.
         /// </summary>
         public string Content { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolStatus/PlatformDataDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolStatus/PlatformDataDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus
 {
@@ -24,5 +25,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus
         /// The current incidents for platform.
         /// </summary>
         public ImmutableList<StatusDto> Incidents { get; init; } = ImmutableList<StatusDto>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolStatus/StatusDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolStatus/StatusDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus
 {
@@ -42,5 +43,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus
         /// The platform list affected by this incident e.g. "windows", "macos".
         /// </summary>
         public ImmutableList<string> Platforms { get; init; } = ImmutableList<string>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolStatus/UpdateDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolStatus/UpdateDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus
 {
@@ -34,5 +35,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus
         /// <example>2023-01-19T02:14:00+00:00</example>
         /// </summary>
         public string UpdatedAt { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/InfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/InfoDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
@@ -34,5 +35,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
         /// </summary>
         [JsonPropertyName("total_turn_count")]
         public int TotalTurnCount { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/MatchDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/MatchDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
 {
     public record MatchDto
     {
@@ -10,5 +12,10 @@
         /// The match info.
         /// </summary>
         public InfoDto Info { get; init; } = new();
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/MetadataDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/MetadataDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
@@ -19,5 +20,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
         /// The list of participant PUUIDs.
         /// </summary>
         public ImmutableList<string> Participants { get; init; } = ImmutableList<string>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/PlayerDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/PlayerDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
@@ -27,5 +28,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
         /// </summary>
         [JsonPropertyName("order_of_play")]
         public int OrderOfPlayer { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorRanked/LeaderboardDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorRanked/LeaderboardDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorRanked
 {
@@ -8,5 +9,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorRanked
         /// The list of players in Master tier.
         /// </summary>
         public ImmutableList<PlayerDto> Players { get; init; } = ImmutableList<PlayerDto>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorRanked/PlayerDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorRanked/PlayerDto.cs
@@ -20,5 +20,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorRanked
         /// </summary>
         [JsonConverter(typeof(IntJsonConverter))]
         public int Lp { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/BanDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/BanDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     public record BanDto
     {
@@ -10,5 +12,10 @@
         /// The pick turn that the ban occured in.
         /// </summary>
         public int PickTurn { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ChampionStats.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ChampionStats.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -30,5 +32,10 @@
         public double PowerMax { get; init; }
         public double PowerRegen { get; init; }
         public double SpellVamp { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/DamageStats.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/DamageStats.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -17,5 +19,10 @@
         public long TrueDamageDone { get; init; }
         public long TrueDamageDoneToChampions { get; init; }
         public long TrueDamageTaken { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/Event.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/Event.cs
@@ -1,9 +1,16 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     public record Event
     {
         public long RealTimestamp { get; init; }
         public long Timestamp { get; init; }
         public string Type { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/Frame.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/Frame.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
@@ -10,5 +11,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         public ImmutableList<Event> Events { get; init; } = ImmutableList<Event>.Empty;
         public ImmutableDictionary<string, ParticipantFrame> ParticipantFrames { get; init; } = ImmutableDictionary<string, ParticipantFrame>.Empty;
         public long Timestamp { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/InfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/InfoDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
@@ -65,5 +66,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// The tournament code used to generate the match.
         /// </summary>
         public string TournamentCode { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/MatchDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/MatchDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     public record MatchDto
     {
@@ -10,5 +12,10 @@
         /// The info of match. The yummy part that most developers want. :eyes:
         /// </summary>
         public InfoDto Info { get; init; } = new();
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/MatchTimelineDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/MatchTimelineDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     public record MatchTimelineDto
     {
@@ -10,5 +12,10 @@
         /// The timeline info of match.
         /// </summary>
         public TimelineInfoDto Info { get; init; } = new();
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/MetadataDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/MetadataDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
@@ -16,5 +17,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// The list of encrypted PUUIDs for summoners that participated in the match.
         /// </summary>
         public ImmutableList<string> Participants { get; init; } = ImmutableList<string>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ObjectiveDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ObjectiveDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     public record ObjectiveDto
     {
@@ -10,5 +12,10 @@
         /// The amount of times this objective was killed.
         /// </summary>
         public int Kills { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ObjectivesDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ObjectivesDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     public record ObjectivesDto
     {
@@ -27,5 +29,10 @@
         /// The lane, base, and nexus towers for a team.
         /// </summary>
         public ObjectiveDto Tower { get; init; } = new();
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ParticipantDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ParticipantDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     public record ParticipantDto
     {
@@ -492,5 +494,10 @@
         /// UNDOCUMENTED
         /// </summary>
         public bool EligibleForProgression { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ParticipantFrame.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ParticipantFrame.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -17,5 +19,10 @@
         public long TimeEnemySpentControlled { get; init; }
         public long TotalGold { get; init; }
         public long Xp { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/PerkStatsDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/PerkStatsDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     public record PerkStatsDto
     {
@@ -14,5 +16,10 @@
         /// The selected Offense perk ID.
         /// </summary>
         public int Offense { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/PerkStyleDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/PerkStyleDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
@@ -16,5 +17,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// The style ID.
         /// </summary>
         public int Style { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/PerkStyleSelectionDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/PerkStyleSelectionDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     /// <summary>
     /// A perk style selection used for Runes Reforged.
@@ -22,5 +24,10 @@
         /// The third variable used for the end of game stat descriptions.
         /// </summary>
         public int Var3 { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/PerksDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/PerksDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
@@ -16,5 +17,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// The selected perk styles for a player.
         /// </summary>
         public ImmutableList<PerkStyleDto> Styles { get; init; } = ImmutableList<PerkStyleDto>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/Position.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/Position.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -7,5 +9,10 @@
     {
         public double X { get; init; }
         public double Y { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/TeamDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/TeamDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
@@ -20,5 +21,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// Whether a team has winned a match e.g. destroyed the enemy nexus.
         /// </summary>
         public bool Win { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/TimelineInfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/TimelineInfoDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
@@ -11,5 +12,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         public ImmutableList<Frame> Frames { get; init; } = ImmutableList<Frame>.Empty;
         public long GameId { get; init; }
         public ImmutableList<TimelineParticipant> Participants { get; init; } = ImmutableList<TimelineParticipant>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/TimelineParticipant.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/TimelineParticipant.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     /// <summary>
     /// UNDOCUMENTED
@@ -7,5 +9,10 @@
     {
         public int ParticipantId { get; init; }
         public string Puuid { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/BannedChampion.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/BannedChampion.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
     public record BannedChampion
     {
@@ -14,5 +16,10 @@
         /// The banning team ID.
         /// </summary>
         public long TeamId { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/CurrentGameInfo.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/CurrentGameInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
@@ -49,5 +50,9 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
         /// </summary>
         public ImmutableList<CurrentGameParticipant> Participants { get; init; } = ImmutableList<CurrentGameParticipant>.Empty;
 
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/CurrentGameParticipant.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/CurrentGameParticipant.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
@@ -44,5 +45,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
         /// The list of Game Customization objects.
         /// </summary>
         public ImmutableList<GameCustomizationObject> GameCustomizationObjects { get; init; } = ImmutableList<GameCustomizationObject>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/FeaturedGameInfo.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/FeaturedGameInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
@@ -48,5 +49,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
         /// The platform ID the game is being played on.
         /// </summary>
         public string PlatformId { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/FeaturedGames.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/FeaturedGames.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
@@ -12,5 +13,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
         /// The suggested interval to wait before making another request for refreshing.
         /// </summary>
         public long ClientRefreshInterval { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/GameCustomizationObject.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/GameCustomizationObject.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
     public record GameCustomizationObject
     {
@@ -10,5 +12,10 @@
         /// The content for Game Customization.
         /// </summary>
         public string Content { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/Observer.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/Observer.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
     public record Observer
     {
@@ -6,5 +8,10 @@
         /// The key used to decrypt the spectator grid game data for playback.
         /// </summary>
         public string EncryptionKey { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/Participant.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/Participant.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
     public record Participant
     {
@@ -30,5 +32,10 @@
         /// The first equipped summoner spell ID.
         /// </summary>
         public long Spell1Id { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/Perks.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/Perks.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
@@ -16,5 +17,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
         /// The secondary runes path.
         /// </summary>
         public long PerkSubStyle { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Summoner/SummonerDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Summoner/SummonerDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Summoner
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.Summoner
 {
     public record SummonerDto
     {
@@ -30,5 +32,10 @@
         /// The summoner level associated with summoner.
         /// </summary>
         public long SummonerLevel { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftLeague/LeagueEntryDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftLeague/LeagueEntryDto.cs
@@ -1,4 +1,5 @@
-﻿using BlossomiShymae.RiotBlossom.Dto.Riot.League;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using BlossomiShymae.RiotBlossom.Dto.Riot.League;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftLeague
 {
@@ -20,5 +21,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftLeague
         public bool? FreshBlood { get; init; }
         public bool? Inactive { get; init; }
         public MiniSeriesDto? MiniSeries { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftLeague/TopRatedLadderEntryDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftLeague/TopRatedLadderEntryDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftLeague
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftLeague
 {
     public record TopRatedLadderEntryDto
     {
@@ -23,5 +25,10 @@
         /// </summary>
         public int Wins { get; init; }
         public int PreviousUpdateLadderPosition { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/CompanionDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/CompanionDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
 {
@@ -12,5 +13,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
         [JsonPropertyName("content_id")]
         public string ContentId { get; init; } = default!;
         public string Species { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/InfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/InfoDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
@@ -39,5 +40,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
         /// </summary>
         [JsonPropertyName("tft_set_number")]
         public int TftSetNumber { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/MatchDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/MatchDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
 {
     public record MatchDto
     {
@@ -10,5 +12,10 @@
         /// The match info.
         /// </summary>
         public InfoDto Info { get; init; } = new();
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/MetadataDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/MetadataDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
@@ -19,5 +20,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
         /// The list of active participant PUUIDs.
         /// </summary>
         public ImmutableList<string> Participants { get; init; } = ImmutableList<string>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/ParticipantDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/ParticipantDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
@@ -54,5 +55,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
         /// The list of active units.
         /// </summary>
         public ImmutableList<UnitDto> Units { get; init; } = ImmutableList<UnitDto>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/TraitDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/TraitDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
 {
@@ -27,5 +28,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
         /// </summary>
         [JsonPropertyName("tier_total")]
         public int TierTotal { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/UnitDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/UnitDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
@@ -30,5 +31,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
         /// The unit tier.
         /// </summary>
         public int Tier { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ActDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ActDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
 {
     public record ActDto
     {
@@ -9,5 +11,10 @@
         public LocalizedNamesDto? LocalizedNames { get; init; }
         public string Id { get; init; } = default!;
         public bool IsActive { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ContentDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ContentDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
 {
@@ -19,5 +20,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
         public ImmutableList<ContentItemDto> PlayerCards { get; init; } = ImmutableList<ContentItemDto>.Empty;
         public ImmutableList<ContentItemDto> PlayerTitles { get; init; } = ImmutableList<ContentItemDto>.Empty;
         public ImmutableList<ActDto> Acts { get; init; } = ImmutableList<ActDto>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ContentItemDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ContentItemDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
 {
     public record ContentItemDto
     {
@@ -13,5 +15,10 @@
         /// This is only included for maps and game modes.
         /// </summary>
         public string AssetPath { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/LocalizedNamesDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/LocalizedNamesDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
 {
@@ -45,5 +46,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
         public string ChineseSimplified { get; init; } = default!;
         [JsonPropertyName("zh-TW")]
         public string ChineseTaiwan { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/AbilityCastsDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/AbilityCastsDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
     public record AbilityCastsDto
     {
@@ -6,5 +8,10 @@
         public int Ability1Casts { get; init; }
         public int Ability2Casts { get; init; }
         public int UltimateCasts { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/AbilityDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/AbilityDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
     public record AbilityDto
     {
@@ -6,5 +8,10 @@
         public string Ability1Effects { get; init; } = default!;
         public string Ability2Effects { get; init; } = default!;
         public string UltimateEffects { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/CoachDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/CoachDto.cs
@@ -1,8 +1,15 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
     public record CoachDto
     {
         public string Puuid { get; init; } = default!;
         public string TeamId { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/DamageDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/DamageDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
     public record DamageDto
     {
@@ -10,5 +12,10 @@
         public int Legshots { get; init; }
         public int Bodyshots { get; init; }
         public int Headshots { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/EconomyDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/EconomyDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
     public record EconomyDto
     {
@@ -7,5 +9,10 @@
         public string Armor { get; init; } = default!;
         public int Remaining { get; init; }
         public int Spent { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/FinishingDamageDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/FinishingDamageDto.cs
@@ -1,9 +1,16 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
     public record FinishingDamageDto
     {
         public string DamageType { get; init; } = default!;
         public string DamageItem { get; init; } = default!;
         public bool IsSecondaryFireMode { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/KillDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/KillDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
@@ -21,5 +22,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
         public ImmutableList<string> Assistants { get; init; } = ImmutableList<string>.Empty;
         public ImmutableList<PlayerLocationsDto> PlayerLocations { get; init; } = ImmutableList<PlayerLocationsDto>.Empty;
         public FinishingDamageDto FinishingDamage { get; init; } = new();
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/LocationDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/LocationDto.cs
@@ -1,8 +1,15 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
     public record LocationDto
     {
         public int X { get; init; }
         public int Y { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
@@ -9,5 +10,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
         public ImmutableList<CoachDto> Coaches { get; init; } = ImmutableList<CoachDto>.Empty;
         public ImmutableList<TeamDto> Teams { get; init; } = ImmutableList<TeamDto>.Empty;
         public ImmutableList<RoundResultDto> RoundResults { get; init; } = ImmutableList<RoundResultDto>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchInfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchInfoDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
     public record MatchInfoDto
     {
@@ -13,5 +15,10 @@
         public string GameMode { get; init; } = default!;
         public bool IsRanked { get; init; }
         public string SeasonId { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchlistDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchlistDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
@@ -6,5 +7,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
     {
         public string Puuid { get; init; } = default!;
         public ImmutableList<MatchlistEntryDto> History { get; init; } = ImmutableList<MatchlistEntryDto>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchlistEntryDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchlistEntryDto.cs
@@ -1,9 +1,16 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
     public record MatchlistEntryDto
     {
         public string MatchId { get; init; } = default!;
         public long GameStartTimeMillis { get; init; }
         public string TeamId { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
     public record PlayerDto
     {
@@ -12,5 +14,10 @@
         public int CompetitiveTier { get; init; }
         public string PlayerCard { get; init; } = default!;
         public string PlayerTitle { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerLocationsDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerLocationsDto.cs
@@ -1,9 +1,16 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
     public record PlayerLocationsDto
     {
         public string Puuid { get; init; } = default!;
         public float ViewRadians { get; init; }
         public LocationDto Location { get; init; } = new();
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerRoundStatsDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerRoundStatsDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
@@ -10,5 +11,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
         public int Score { get; init; }
         public EconomyDto Economy { get; init; } = new();
         public AbilityDto Ability { get; init; } = new();
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerStatsDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerStatsDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
     public record PlayerStatsDto
     {
@@ -9,5 +11,10 @@
         public int Assists { get; init; }
         public int PlaytimeMillis { get; init; }
         public AbilityCastsDto AbilityCasts { get; init; } = new();
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/RecentMatchesDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/RecentMatchesDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
@@ -6,5 +7,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
     {
         public long CurrentTime { get; init; }
         public ImmutableList<string> MatchIds { get; init; } = ImmutableList<string>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/RoundResultDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/RoundResultDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
@@ -19,5 +20,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
         public LocationDto DefuseLocation { get; init; } = new();
         public ImmutableList<PlayerRoundStatsDto> PlayerStats { get; init; } = ImmutableList<PlayerRoundStatsDto>.Empty;
         public string RoundResultCode { get; init; } = default!;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/TeamDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/TeamDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
     public record TeamDto
     {
@@ -22,5 +24,10 @@
         /// The team points scored. Number of kills in deathmatch.
         /// </summary>
         public int NumPoints { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValRanked/LeaderboardDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValRanked/LeaderboardDto.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using BlossomiShymae.RiotBlossom.Core;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValRanked
 {
@@ -20,5 +21,10 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValRanked
         /// The list of participating players.
         /// </summary>
         public ImmutableList<PlayerDto> Players { get; init; } = ImmutableList<PlayerDto>.Empty;
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValRanked/PlayerDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValRanked/PlayerDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValRanked
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValRanked
 {
     public record PlayerDto
     {
@@ -17,5 +19,10 @@
         public long LeaderboardRank { get; init; }
         public long RankedRating { get; init; }
         public long NumberOfWins { get; init; }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(this);
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossomTests/Core/PrettyPrinterTests.cs
+++ b/BlossomiShymae.RiotBlossomTests/Core/PrettyPrinterTests.cs
@@ -1,0 +1,22 @@
+﻿using BlossomiShymae.RiotBlossom.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Diagnostics;
+
+namespace BlossomiShymae.RiotBlossomTests.Core
+{
+    [TestClass()]
+    public class PrettyPrinterTests
+    {
+        [TestMethod()]
+        public async Task Printer_WithNestedObject_ShouldReturnPrettyString()
+        {
+            IRiotBlossomClient client = StubConfig.Client;
+
+            var itemDictionary = await client.CommunityDragon.GetItemDictionaryAsync();
+            string prettyItems = PrettyPrinter.GetString(itemDictionary);
+            Trace.WriteLine(prettyItems);
+
+            Assert.IsTrue(prettyItems.Length > 0);
+        }
+    }
+}

--- a/BlossomiShymae.RiotBlossomTests/Core/PrettyPrinterTests.cs
+++ b/BlossomiShymae.RiotBlossomTests/Core/PrettyPrinterTests.cs
@@ -1,6 +1,7 @@
 ﻿using BlossomiShymae.RiotBlossom.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Diagnostics;
+using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossomTests.Core
 {
@@ -17,6 +18,40 @@ namespace BlossomiShymae.RiotBlossomTests.Core
             Trace.WriteLine(prettyItems);
 
             Assert.IsTrue(prettyItems.Length > 0);
+        }
+
+        [TestMethod()]
+        public void Printer_WithJsonPropertyNameAttribute_ShouldReturnPrettyString()
+        {
+            JsonPropertyNameAttributeDto dto = new() { MatchId = "NA_20" };
+
+            string pretty = PrettyPrinter.GetString(dto);
+            Trace.WriteLine(pretty);
+
+            Assert.IsTrue(pretty.Contains("match_id"));
+        }
+
+        [TestMethod()]
+        public void Printer_WithJsonConverterAttribute_ShouldReturnPrettyString()
+        {
+            JsonConverterAttributeDto dto = new() { Lp = 10 };
+
+            string pretty = PrettyPrinter.GetString(dto);
+            Trace.WriteLine(pretty);
+
+            Assert.IsTrue(pretty.Contains("10") && !pretty.Contains("10.0"));
+        }
+
+        internal record JsonPropertyNameAttributeDto
+        {
+            [JsonPropertyName("match_id")]
+            public string MatchId { get; init; } = default!;
+        }
+
+        internal record JsonConverterAttributeDto
+        {
+            [JsonConverter(typeof(IntJsonConverter))]
+            public int Lp { get; init; }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -199,13 +199,17 @@ SummonerDto summoner = await client.Riot.Summoner
 Console.WriteLine(summoner);
 ```
 
-Output:
+Output via `ToString`, which internally uses `PrettyPrinter.GetString`:
 ```
-SummonerDto { AccountId = 0WvZHECxpBFNlntYzcCNyDkGeaqA6vthcLsklngrPVYofWE, ProfileIconId = 5367,
-RevisionDate = 1675651090000, Name = uwuie time,
-Id = Ao5ffQ2dOV-99YKs_iB0g2EGzGD159jXIk2Z5MjvMafLwbQ,
-Puuid = Bd1zj7cFt3MlCZl2GI-5N94D2PHRsfpsjl-6ZM9LjXIm90Bz4JAdwR6Kw4fzbSPFfLoQI5p9hGIhfA,
-SummonerLevel = 936 }
+SummonerDto {
+  "AccountId": "0WvZHECxpBFNlntYzcCNyDkGeaqA6vthcLsklngrPVYofWE",
+  "ProfileIconId": 5367,
+  "RevisionDate": 1675651090000,
+  "Name": "uwuie time",
+  "Id": "Ao5ffQ2dOV-99YKs_iB0g2EGzGD159jXIk2Z5MjvMafLwbQ",
+  "Puuid": "Bd1zj7cFt3MlCZl2GI-5N94D2PHRsfpsjl-6ZM9LjXIm90Bz4JAdwR6Kw4fzbSPFfLoQI5p9hGIhfA",
+  "SummonerLevel": 936
+}
 ```
 
 If we're commonly making requests to the same API, we can store an API reference to make requests with instead!
@@ -250,6 +254,9 @@ ImmutableDictionary<int, Item> itemDictionary =
 itemDictionary
     .ToList()
     .ForEach(kvp => Console.WriteLine($"{kvp.Key}: {kvp.Value.Name}"));
+
+// Moonstone Renewer
+Console.WriteLine(itemDictionary[6617]);
 ```
 
 Output:
@@ -260,6 +267,23 @@ Output:
 1011: Giant's Belt
 1018: Cloak of Agility
 ...
+```
+```
+Item {
+  "Name": "Moonstone Renewer",
+  "Rune": {
+    "IsRune": false,
+    "Tier": 0,
+    "Type": null
+  },
+  "Gold": {
+    "Base": 750,
+    "Total": 2500,
+    "Sell": 1750,
+    "Purchasable": true
+  },
+...
+}
 ```
 
 ## CommunityDragon!?
@@ -273,13 +297,36 @@ Champion champion = await client.CommunityDragon.GetChampionByIdAsync(887);
 Console.WriteLine(champion);
 ```
 
+Output:
 ```
-Champion { Id = 887, Name = Gwen, Alias = Gwen, Title = The Hallowed Seamstress,
-ShortBio = A former doll transformed and brought to life by magic, Gwen wields the very tools that
-once created her. She carries the weight of her maker's love with every step, taking nothing for
-granted. At her command is the Hallowed Mist, an ancient and protective magic that has blessed
-Gwen's scissors, needles, and sewing thread. So much is new to her, but Gwen remains joyfully
-determined to fight for the good that survives in a broken world.,  ...}
+Champion {
+  "Id": 887,
+  "Name": "Gwen",
+  "Alias": "Gwen",
+  "Title": "The Hallowed Seamstress",
+  "ShortBio": "A former doll transformed and brought to life by magic...",
+  "TacticalInfo": {
+    "Style": 5,
+    "Difficulty": 2,
+    "DamageType": "kMagic"
+  },
+  "PlaystyleInfo": {
+    "Damage": 3,
+    "Durability": 2,
+    "CrowdControl": 1,
+    "Mobility": 3,
+    "Utility": 1
+  },
+  "SquarePortraitPath": "/lol-game-data/assets/v1/champion-icons/887.png",
+  "StingerSfxPath": "/lol-game-data/assets/v1/champion-sfx-audios/887.ogg",
+  "ChooseVoPath": "/lol-game-data/assets/v1/champion-choose-vo/887.ogg",
+  "BanVoPath": "/lol-game-data/assets/v1/champion-ban-vo/887.ogg",
+  "Roles": [
+    "fighter",
+    "assassin"
+  ],
+  ...
+ }
 ```
 
 # API Interfaces
@@ -514,6 +561,7 @@ These are used internally for projecting values when making requests to the Riot
 - `TftLeagueQueueMapper`
 - `PlatformMapper`
 - `PlatformToRegionConverter`
+- `PrettyPrinter`
 - `RegionMapper`
 - `ValRegionMapper`
 


### PR DESCRIPTION
Resolves #10 !

# Dto
- Update `ToString` to not use compiler-generated implementation. Uses `PrettyPrinter.ToString`! Should be an improvement for usability and debugging purposes.

# Core
- Add `PrettyPrinter` for getting pretty printed strings! Should be useful for printing `System.Collections` namespace objects in the console.