### PR TITLE
Add `GetAsync` headers overload for Riot interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -372,3 +372,4 @@ node_modules
 .env
 dist
 .DS_Store
+/.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-  "grammarly.selectors": [
-    {
-      "language": "markdown",
-      "scheme": "file"
-    }
-  ]
-}

--- a/BlossomiShymae.RiotBlossom/Api/ComposableApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/ComposableApi.cs
@@ -5,76 +5,76 @@ using System.Text.Json.Nodes;
 
 namespace BlossomiShymae.RiotBlossom.Api
 {
-	/// <summary>
-	/// <para>Represents a composable API to fetch data from injected <see cref="IHttpClient"/>.</para>
-	/// <para>I really think this internal class is a fugly mess so it will probably be refactored soon at some point. - BlossomiShymae</para>
-	/// </summary>
-	/// <typeparam name="T"></typeparam>
-	internal class ComposableApi<T>
-	{
-		private static readonly JsonSerializerOptions s_options = new()
-		{
-			PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-			DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
-			WriteIndented = true
-		};
-		private readonly IHttpClient _httpClient;
+    /// <summary>
+    /// <para>Represents a composable API to fetch data from injected <see cref="IHttpClient"/>.</para>
+    /// <para>I really think this internal class is a fugly mess so it will probably be refactored soon at some point. - BlossomiShymae</para>
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal class ComposableApi<T>
+    {
+        private static readonly JsonSerializerOptions s_options = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true
+        };
+        private readonly IHttpClient _httpClient;
 
-		public ComposableApi(IHttpClient httpClient)
-		{
-			_httpClient = httpClient;
-		}
+        public ComposableApi(IHttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
 
-		internal U Deserialize<U>(JsonObject obj)
-		{
-			var value = JsonSerializer.Deserialize<U>(obj, s_options);
-			return value == null ? throw new NullReferenceException($"Failed to deserialize object {obj}") : value;
-		}
+        internal U Deserialize<U>(JsonObject obj)
+        {
+            var value = JsonSerializer.Deserialize<U>(obj, s_options);
+            return value == null ? throw new NullReferenceException($"Failed to deserialize object {obj}") : value;
+        }
 
-		internal U? DeserializeNode<U>(JsonNode node)
-		{
-			if (node is JsonObject obj)
-				return JsonSerializer.Deserialize<U>(obj.AsObject(), s_options);
-			if (node is JsonArray array)
-				return JsonSerializer.Deserialize<U>(array.AsArray(), s_options);
-			if (node is JsonValue value)
-				return JsonSerializer.Deserialize<U>(value.AsValue(), s_options);
-			throw new InvalidOperationException("JsonNode is not a JsonObject, JsonArray, nor JsonValue");
-		}
+        internal U? DeserializeNode<U>(JsonNode node)
+        {
+            if (node is JsonObject obj)
+                return JsonSerializer.Deserialize<U>(obj.AsObject(), s_options);
+            if (node is JsonArray array)
+                return JsonSerializer.Deserialize<U>(array.AsArray(), s_options);
+            if (node is JsonValue value)
+                return JsonSerializer.Deserialize<U>(value.AsValue(), s_options);
+            throw new InvalidOperationException("JsonNode is not a JsonObject, JsonArray, nor JsonValue");
+        }
 
-		internal async Task<byte[]> GetByteArrayAsync(string uri)
-		{
-			return await _httpClient.GetByteArrayAsync(uri);
-		}
+        internal async Task<byte[]> GetByteArrayAsync(string uri)
+        {
+            return await _httpClient.GetByteArrayAsync(uri);
+        }
 
-		internal async Task<T> GetValueAsync(string uri)
-		{
-			string data = await _httpClient.GetStringAsync(uri, string.Empty);
-			var dto = JsonSerializer.Deserialize<T>(data, s_options);
-			return dto == null ? throw new NullReferenceException($"Failed to deserialize response data {data}") : dto;
-		}
+        internal async Task<T> GetValueAsync(string uri)
+        {
+            string data = await _httpClient.GetStringAsync(uri, string.Empty);
+            var dto = JsonSerializer.Deserialize<T>(data, s_options);
+            return dto == null ? throw new NullReferenceException($"Failed to deserialize response data {data}") : dto;
+        }
 
-		internal async Task<T> GetValueAsync(string routingValue, string uri)
-			=> await GetValueAsync(routingValue, uri, ImmutableDictionary<string, string>.Empty);
+        internal async Task<T> GetValueAsync(string routingValue, string uri)
+            => await GetValueAsync(routingValue, uri, ImmutableDictionary<string, string>.Empty);
 
-		internal async Task<T> GetValueAsync(string routingValue, string uri, IDictionary<string, string> headers)
-		{
-			if (_httpClient is RiotHttpClient client)
-			{
-				string data = await client.GetStringAsync(uri, routingValue, headers);
-				var options = new JsonSerializerOptions
-				{
-					PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-					DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
-					WriteIndented = true,
-				};
-				var dto = JsonSerializer.Deserialize<T>(data, options);
-				return dto == null ? throw new NullReferenceException($"Failed to deserialize response data {data}") : dto;
-			}
-			else
-			{
-				throw new InvalidOperationException("Method can only operate if http client is a Riot http client");
-			}
-		}
-	}
+        internal async Task<T> GetValueAsync(string routingValue, string uri, IDictionary<string, string> headers)
+        {
+            if (_httpClient is RiotHttpClient client)
+            {
+                string data = await client.GetStringAsync(uri, routingValue, headers);
+                var options = new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+                    WriteIndented = true,
+                };
+                var dto = JsonSerializer.Deserialize<T>(data, options);
+                return dto == null ? throw new NullReferenceException($"Failed to deserialize response data {data}") : dto;
+            }
+            else
+            {
+                throw new InvalidOperationException("Method can only operate if http client is a Riot http client");
+            }
+        }
+    }
 }

--- a/BlossomiShymae.RiotBlossom/Api/ComposableApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/ComposableApi.cs
@@ -1,76 +1,80 @@
 ﻿using BlossomiShymae.RiotBlossom.Http;
+using System.Collections.Immutable;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace BlossomiShymae.RiotBlossom.Api
 {
-    /// <summary>
-    /// <para>Represents a composable API to fetch data from injected <see cref="IHttpClient"/>.</para>
-    /// <para>I really think this internal class is a fugly mess so it will probably be refactored soon at some point. - BlossomiShymae</para>
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    internal class ComposableApi<T>
-    {
-        private static readonly JsonSerializerOptions s_options = new()
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
-            WriteIndented = true
-        };
-        private readonly IHttpClient _httpClient;
+	/// <summary>
+	/// <para>Represents a composable API to fetch data from injected <see cref="IHttpClient"/>.</para>
+	/// <para>I really think this internal class is a fugly mess so it will probably be refactored soon at some point. - BlossomiShymae</para>
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	internal class ComposableApi<T>
+	{
+		private static readonly JsonSerializerOptions s_options = new()
+		{
+			PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+			DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+			WriteIndented = true
+		};
+		private readonly IHttpClient _httpClient;
 
-        public ComposableApi(IHttpClient httpClient)
-        {
-            _httpClient = httpClient;
-        }
+		public ComposableApi(IHttpClient httpClient)
+		{
+			_httpClient = httpClient;
+		}
 
-        internal U Deserialize<U>(JsonObject obj)
-        {
-            var value = JsonSerializer.Deserialize<U>(obj, s_options);
-            return value == null ? throw new NullReferenceException($"Failed to deserialize object {obj}") : value;
-        }
+		internal U Deserialize<U>(JsonObject obj)
+		{
+			var value = JsonSerializer.Deserialize<U>(obj, s_options);
+			return value == null ? throw new NullReferenceException($"Failed to deserialize object {obj}") : value;
+		}
 
-        internal U? DeserializeNode<U>(JsonNode node)
-        {
-            if (node is JsonObject obj)
-                return JsonSerializer.Deserialize<U>(obj.AsObject(), s_options);
-            if (node is JsonArray array)
-                return JsonSerializer.Deserialize<U>(array.AsArray(), s_options);
-            if (node is JsonValue value)
-                return JsonSerializer.Deserialize<U>(value.AsValue(), s_options);
-            throw new InvalidOperationException("JsonNode is not a JsonObject, JsonArray, nor JsonValue");
-        }
+		internal U? DeserializeNode<U>(JsonNode node)
+		{
+			if (node is JsonObject obj)
+				return JsonSerializer.Deserialize<U>(obj.AsObject(), s_options);
+			if (node is JsonArray array)
+				return JsonSerializer.Deserialize<U>(array.AsArray(), s_options);
+			if (node is JsonValue value)
+				return JsonSerializer.Deserialize<U>(value.AsValue(), s_options);
+			throw new InvalidOperationException("JsonNode is not a JsonObject, JsonArray, nor JsonValue");
+		}
 
-        internal async Task<byte[]> GetByteArrayAsync(string uri)
-        {
-            return await _httpClient.GetByteArrayAsync(uri);
-        }
+		internal async Task<byte[]> GetByteArrayAsync(string uri)
+		{
+			return await _httpClient.GetByteArrayAsync(uri);
+		}
 
-        internal async Task<T> GetValueAsync(string uri)
-        {
-            string data = await _httpClient.GetStringAsync(uri, string.Empty);
-            var dto = JsonSerializer.Deserialize<T>(data, s_options);
-            return dto == null ? throw new NullReferenceException($"Failed to deserialize response data {data}") : dto;
-        }
+		internal async Task<T> GetValueAsync(string uri)
+		{
+			string data = await _httpClient.GetStringAsync(uri, string.Empty);
+			var dto = JsonSerializer.Deserialize<T>(data, s_options);
+			return dto == null ? throw new NullReferenceException($"Failed to deserialize response data {data}") : dto;
+		}
 
-        internal async Task<T> GetValueAsync(string routingValue, string uri)
-        {
-            if (_httpClient is RiotHttpClient client)
-            {
-                string data = await client.GetStringAsync(uri, routingValue);
-                var options = new JsonSerializerOptions
-                {
-                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                    DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
-                    WriteIndented = true,
-                };
-                var dto = JsonSerializer.Deserialize<T>(data, options);
-                return dto == null ? throw new NullReferenceException($"Failed to deserialize response data {data}") : dto;
-            }
-            else
-            {
-                throw new InvalidOperationException("Method can only operate if http client is a Riot http client");
-            }
-        }
-    }
+		internal async Task<T> GetValueAsync(string routingValue, string uri)
+			=> await GetValueAsync(routingValue, uri, ImmutableDictionary<string, string>.Empty);
+
+		internal async Task<T> GetValueAsync(string routingValue, string uri, IDictionary<string, string> headers)
+		{
+			if (_httpClient is RiotHttpClient client)
+			{
+				string data = await client.GetStringAsync(uri, routingValue, headers);
+				var options = new JsonSerializerOptions
+				{
+					PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+					DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+					WriteIndented = true,
+				};
+				var dto = JsonSerializer.Deserialize<T>(data, options);
+				return dto == null ? throw new NullReferenceException($"Failed to deserialize response data {data}") : dto;
+			}
+			else
+			{
+				throw new InvalidOperationException("Method can only operate if http client is a Riot http client");
+			}
+		}
+	}
 }

--- a/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
@@ -4,238 +4,238 @@ using System.Text.Json.Nodes;
 
 namespace BlossomiShymae.RiotBlossom.Api
 {
-	public interface IRiotApi
-	{
-		/// <summary>
-		/// Get the deserialized object, array, or scalar response from endpoint by route and path.
-		/// <para>
-		/// Object
-		/// <code>
-		/// SummonerDto summoner = await client.Riot.GetAsync&lt;SummonerDto&gt;("na1", "/lol/summoner/v4/summoners/by-name/uwuie time");
-		/// </code>
-		/// </para>
-		/// <para>
-		/// Array
-		/// <code>
-		/// List&lt;string&gt; matchIds = await client.Riot.GetAsync&lt;List&lt;string&gt;&gt;("na1", $"/lol/match/v5/matches/by-puuid/{puuid}/ids");
-		/// </code>
-		/// </para>
-		/// <para>
-		/// Scalar
-		/// <code>
-		/// int totalMasteryScore = await client.Riot.GetAsync&lt;int&gt;("na1", $"/lol/champion-mastery/v4/scores/by-summoner/{encryptedSummonerId}");
-		/// </code>
-		/// </para>
-		/// <exception>
-		/// <para>Exceptions</para>
-		/// <para><see cref="NullReferenceException"/></para>
-		/// </exception>
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="route">The raw routing value for request e.g. "na1", "americas", "esports", "ap", etc.</param>
-		/// <param name="path">The path for endpoint e.g. "/lol/status/v4/platform-data".</param>
-		/// <returns></returns>
-		Task<T> GetAsync<T>(string route, string path);
-		/// <summary>
-		/// Get the deserialized object, array, or scalar response from endpoint by route and path with applied headers.
-		/// <para>
-		/// Object
-		/// <code>
-		/// SummonerDto summoner = await client.Riot.GetAsync&lt;SummonerDto&gt;("na1", "/lol/summoner/v4/summoners/by-name/uwuie time");
-		/// </code>
-		/// </para>
-		/// <para>
-		/// Array
-		/// <code>
-		/// List&lt;string&gt; matchIds = await client.Riot.GetAsync&lt;List&lt;string&gt;&gt;("na1", $"/lol/match/v5/matches/by-puuid/{puuid}/ids");
-		/// </code>
-		/// </para>
-		/// <para>
-		/// Scalar
-		/// <code>
-		/// int totalMasteryScore = await client.Riot.GetAsync&lt;int&gt;("na1", $"/lol/champion-mastery/v4/scores/by-summoner/{encryptedSummonerId}");
-		/// </code>
-		/// </para>
-		/// <exception>
-		/// <para>Exceptions</para>
-		/// <para><see cref="NullReferenceException"/></para>
-		/// </exception>
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="route">The raw routing value for request e.g. "na1", "americas", "esports", "ap", etc.</param>
-		/// <param name="path">The path for endpoint e.g. "/lol/status/v4/platform-data".</param>
-		/// <param name="headers">The HTTP headers to send with request.</param>
-		/// <returns></returns>
-		Task<T> GetAsync<T>(string route, string path, IDictionary<string, string> headers);
-		/// <summary>
-		/// The API for Account-v1 endpoints.
-		/// </summary>
-		IAccountApi Account { get; }
-		/// <summary>
-		/// The API for Champion-v3 endpoints.
-		/// </summary>
-		IChampionApi Champion { get; }
-		/// <summary>
-		/// The API for Champion-Mastery-v4 endpoints.
-		/// </summary>
-		IChampionMasteryApi ChampionMastery { get; }
-		/// <summary>
-		/// The API for Clash-v1 endpoints.
-		/// </summary>
-		IClashApi Clash { get; }
-		/// <summary>
-		/// The API for League-v4 endpoints.
-		/// </summary>
-		ILeagueApi League { get; }
-		/// <summary>
-		/// The API for Lol-Challenges-v1 endpoints.
-		/// </summary>
-		ILolChallengesApi LolChallenges { get; }
-		/// <summary>
-		/// The API for Lol-Status-v4 endpoint.
-		/// </summary>
-		ILolStatusApi LolStatus { get; }
-		/// <summary>
-		/// The API for Lor-Match-v1 endpoints.
-		/// </summary>
-		ILorMatchApi LorMatch { get; }
-		/// <summary>
-		/// The API for Lor-Ranked-v1 endpoint.
-		/// </summary>
-		ILorRankedApi LorRanked { get; }
-		/// <summary>
-		/// The API for Lor-Status-v1 endpoint.
-		/// </summary>
-		ILorStatusApi LorStatus { get; }
-		/// <summary>
-		/// The API for Match-v5 endpoints.
-		/// </summary>
-		IMatchApi Match { get; }
-		/// <summary>
-		/// The Api for Spectator-v4 endpoints.
-		/// </summary>
-		ISpectatorApi Spectator { get; }
-		/// <summary>
-		/// The API for Summoner-v4 endpoints.
-		/// </summary>
-		ISummonerApi Summoner { get; }
-		/// <summary>
-		/// The API for Tft-League-v1 endpoints.
-		/// </summary>
-		ITftLeagueApi TftLeague { get; }
-		/// <summary>
-		/// The API for Tft-Match-v1 endpoints.
-		/// </summary>
-		ITftMatchApi TftMatch { get; }
-		/// <summary>
-		/// The API for Tft-Status-v1 endpoints.
-		/// </summary>
-		ITftStatusApi TftStatus { get; }
-		/// <summary>
-		/// The API for Tft-Summoner-v1 endpoints.
-		/// </summary>
-		ITftSummonerApi TftSummoner { get; }
-		/// <summary>
-		/// The API for Val-Content-v1 endpoint.
-		/// </summary>
-		IValContentApi ValContent { get; }
-		/// <summary>
-		/// <para>The API for Val-Match-v1 endpoint.</para>
-		/// <para>Note: This API requires an authorized production API key for access!</para>
-		/// </summary>
-		IValMatchApi ValMatch { get; }
-		/// <summary>
-		/// The API for Val-Ranked-v1 endpoint.
-		/// </summary>
-		IValRankedApi ValRanked { get; }
-		/// <summary>
-		/// The API for Val-Status-v1 endpoint.
-		/// </summary>
-		IValStatusApi ValStatus { get; }
-	}
+    public interface IRiotApi
+    {
+        /// <summary>
+        /// Get the deserialized object, array, or scalar response from endpoint by route and path.
+        /// <para>
+        /// Object
+        /// <code>
+        /// SummonerDto summoner = await client.Riot.GetAsync&lt;SummonerDto&gt;("na1", "/lol/summoner/v4/summoners/by-name/uwuie time");
+        /// </code>
+        /// </para>
+        /// <para>
+        /// Array
+        /// <code>
+        /// List&lt;string&gt; matchIds = await client.Riot.GetAsync&lt;List&lt;string&gt;&gt;("na1", $"/lol/match/v5/matches/by-puuid/{puuid}/ids");
+        /// </code>
+        /// </para>
+        /// <para>
+        /// Scalar
+        /// <code>
+        /// int totalMasteryScore = await client.Riot.GetAsync&lt;int&gt;("na1", $"/lol/champion-mastery/v4/scores/by-summoner/{encryptedSummonerId}");
+        /// </code>
+        /// </para>
+        /// <exception>
+        /// <para>Exceptions</para>
+        /// <para><see cref="NullReferenceException"/></para>
+        /// </exception>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="route">The raw routing value for request e.g. "na1", "americas", "esports", "ap", etc.</param>
+        /// <param name="path">The path for endpoint e.g. "/lol/status/v4/platform-data".</param>
+        /// <returns></returns>
+        Task<T> GetAsync<T>(string route, string path);
+        /// <summary>
+        /// Get the deserialized object, array, or scalar response from endpoint by route and path with applied headers.
+        /// <para>
+        /// Object
+        /// <code>
+        /// SummonerDto summoner = await client.Riot.GetAsync&lt;SummonerDto&gt;("na1", "/lol/summoner/v4/summoners/by-name/uwuie time");
+        /// </code>
+        /// </para>
+        /// <para>
+        /// Array
+        /// <code>
+        /// List&lt;string&gt; matchIds = await client.Riot.GetAsync&lt;List&lt;string&gt;&gt;("na1", $"/lol/match/v5/matches/by-puuid/{puuid}/ids");
+        /// </code>
+        /// </para>
+        /// <para>
+        /// Scalar
+        /// <code>
+        /// int totalMasteryScore = await client.Riot.GetAsync&lt;int&gt;("na1", $"/lol/champion-mastery/v4/scores/by-summoner/{encryptedSummonerId}");
+        /// </code>
+        /// </para>
+        /// <exception>
+        /// <para>Exceptions</para>
+        /// <para><see cref="NullReferenceException"/></para>
+        /// </exception>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="route">The raw routing value for request e.g. "na1", "americas", "esports", "ap", etc.</param>
+        /// <param name="path">The path for endpoint e.g. "/lol/status/v4/platform-data".</param>
+        /// <param name="headers">The HTTP headers to send with request.</param>
+        /// <returns></returns>
+        Task<T> GetAsync<T>(string route, string path, IDictionary<string, string> headers);
+        /// <summary>
+        /// The API for Account-v1 endpoints.
+        /// </summary>
+        IAccountApi Account { get; }
+        /// <summary>
+        /// The API for Champion-v3 endpoints.
+        /// </summary>
+        IChampionApi Champion { get; }
+        /// <summary>
+        /// The API for Champion-Mastery-v4 endpoints.
+        /// </summary>
+        IChampionMasteryApi ChampionMastery { get; }
+        /// <summary>
+        /// The API for Clash-v1 endpoints.
+        /// </summary>
+        IClashApi Clash { get; }
+        /// <summary>
+        /// The API for League-v4 endpoints.
+        /// </summary>
+        ILeagueApi League { get; }
+        /// <summary>
+        /// The API for Lol-Challenges-v1 endpoints.
+        /// </summary>
+        ILolChallengesApi LolChallenges { get; }
+        /// <summary>
+        /// The API for Lol-Status-v4 endpoint.
+        /// </summary>
+        ILolStatusApi LolStatus { get; }
+        /// <summary>
+        /// The API for Lor-Match-v1 endpoints.
+        /// </summary>
+        ILorMatchApi LorMatch { get; }
+        /// <summary>
+        /// The API for Lor-Ranked-v1 endpoint.
+        /// </summary>
+        ILorRankedApi LorRanked { get; }
+        /// <summary>
+        /// The API for Lor-Status-v1 endpoint.
+        /// </summary>
+        ILorStatusApi LorStatus { get; }
+        /// <summary>
+        /// The API for Match-v5 endpoints.
+        /// </summary>
+        IMatchApi Match { get; }
+        /// <summary>
+        /// The Api for Spectator-v4 endpoints.
+        /// </summary>
+        ISpectatorApi Spectator { get; }
+        /// <summary>
+        /// The API for Summoner-v4 endpoints.
+        /// </summary>
+        ISummonerApi Summoner { get; }
+        /// <summary>
+        /// The API for Tft-League-v1 endpoints.
+        /// </summary>
+        ITftLeagueApi TftLeague { get; }
+        /// <summary>
+        /// The API for Tft-Match-v1 endpoints.
+        /// </summary>
+        ITftMatchApi TftMatch { get; }
+        /// <summary>
+        /// The API for Tft-Status-v1 endpoints.
+        /// </summary>
+        ITftStatusApi TftStatus { get; }
+        /// <summary>
+        /// The API for Tft-Summoner-v1 endpoints.
+        /// </summary>
+        ITftSummonerApi TftSummoner { get; }
+        /// <summary>
+        /// The API for Val-Content-v1 endpoint.
+        /// </summary>
+        IValContentApi ValContent { get; }
+        /// <summary>
+        /// <para>The API for Val-Match-v1 endpoint.</para>
+        /// <para>Note: This API requires an authorized production API key for access!</para>
+        /// </summary>
+        IValMatchApi ValMatch { get; }
+        /// <summary>
+        /// The API for Val-Ranked-v1 endpoint.
+        /// </summary>
+        IValRankedApi ValRanked { get; }
+        /// <summary>
+        /// The API for Val-Status-v1 endpoint.
+        /// </summary>
+        IValStatusApi ValStatus { get; }
+    }
 
-	internal class RiotApi : IRiotApi
-	{
-		private readonly AccountApi _accountApi;
-		private readonly ChampionApi _championApi;
-		private readonly ChampionMasteryApi _championMasteryApi;
-		private readonly ClashApi _clashApi;
-		private readonly LeagueApi _leagueApi;
-		private readonly LolChallengesApi _lolChallengesApi;
-		private readonly LolStatusApi _lolStatusApi;
-		private readonly LorMatchApi _lorMatchApi;
-		private readonly LorRankedApi _lorRankedApi;
-		private readonly LorStatusApi _lorStatusApi;
-		private readonly MatchApi _matchApi;
-		private readonly SpectatorApi _spectatorApi;
-		private readonly SummonerApi _summonerApi;
-		private readonly TftLeagueApi _tftLeagueApi;
-		private readonly TftMatchApi _tftMatchApi;
-		private readonly TftStatusApi _tftStatusApi;
-		private readonly TftSummonerApi _tftSummonerApi;
-		private readonly ValContentApi _valContentApi;
-		private readonly ValMatchApi _valMatchApi;
-		private readonly ValRankedApi _valRankedApi;
-		private readonly ValStatusApi _valStatusApi;
-		private readonly ComposableApi<JsonNode> _jsonNodeApi;
-		public IAccountApi Account => _accountApi;
-		public IChampionApi Champion => _championApi;
-		public IChampionMasteryApi ChampionMastery => _championMasteryApi;
-		public IClashApi Clash => _clashApi;
-		public ILeagueApi League => _leagueApi;
-		public ILolChallengesApi LolChallenges => _lolChallengesApi;
-		public ILolStatusApi LolStatus => _lolStatusApi;
-		public ILorMatchApi LorMatch => _lorMatchApi;
-		public ILorRankedApi LorRanked => _lorRankedApi;
-		public ILorStatusApi LorStatus => _lorStatusApi;
-		public IMatchApi Match => _matchApi;
-		public ISpectatorApi Spectator => _spectatorApi;
-		public ISummonerApi Summoner => _summonerApi;
-		public ITftLeagueApi TftLeague => _tftLeagueApi;
-		public ITftMatchApi TftMatch => _tftMatchApi;
-		public ITftStatusApi TftStatus => _tftStatusApi;
-		public ITftSummonerApi TftSummoner => _tftSummonerApi;
-		public IValContentApi ValContent => _valContentApi;
-		public IValMatchApi ValMatch => _valMatchApi;
-		public IValRankedApi ValRanked => _valRankedApi;
-		public IValStatusApi ValStatus => _valStatusApi;
+    internal class RiotApi : IRiotApi
+    {
+        private readonly AccountApi _accountApi;
+        private readonly ChampionApi _championApi;
+        private readonly ChampionMasteryApi _championMasteryApi;
+        private readonly ClashApi _clashApi;
+        private readonly LeagueApi _leagueApi;
+        private readonly LolChallengesApi _lolChallengesApi;
+        private readonly LolStatusApi _lolStatusApi;
+        private readonly LorMatchApi _lorMatchApi;
+        private readonly LorRankedApi _lorRankedApi;
+        private readonly LorStatusApi _lorStatusApi;
+        private readonly MatchApi _matchApi;
+        private readonly SpectatorApi _spectatorApi;
+        private readonly SummonerApi _summonerApi;
+        private readonly TftLeagueApi _tftLeagueApi;
+        private readonly TftMatchApi _tftMatchApi;
+        private readonly TftStatusApi _tftStatusApi;
+        private readonly TftSummonerApi _tftSummonerApi;
+        private readonly ValContentApi _valContentApi;
+        private readonly ValMatchApi _valMatchApi;
+        private readonly ValRankedApi _valRankedApi;
+        private readonly ValStatusApi _valStatusApi;
+        private readonly ComposableApi<JsonNode> _jsonNodeApi;
+        public IAccountApi Account => _accountApi;
+        public IChampionApi Champion => _championApi;
+        public IChampionMasteryApi ChampionMastery => _championMasteryApi;
+        public IClashApi Clash => _clashApi;
+        public ILeagueApi League => _leagueApi;
+        public ILolChallengesApi LolChallenges => _lolChallengesApi;
+        public ILolStatusApi LolStatus => _lolStatusApi;
+        public ILorMatchApi LorMatch => _lorMatchApi;
+        public ILorRankedApi LorRanked => _lorRankedApi;
+        public ILorStatusApi LorStatus => _lorStatusApi;
+        public IMatchApi Match => _matchApi;
+        public ISpectatorApi Spectator => _spectatorApi;
+        public ISummonerApi Summoner => _summonerApi;
+        public ITftLeagueApi TftLeague => _tftLeagueApi;
+        public ITftMatchApi TftMatch => _tftMatchApi;
+        public ITftStatusApi TftStatus => _tftStatusApi;
+        public ITftSummonerApi TftSummoner => _tftSummonerApi;
+        public IValContentApi ValContent => _valContentApi;
+        public IValMatchApi ValMatch => _valMatchApi;
+        public IValRankedApi ValRanked => _valRankedApi;
+        public IValStatusApi ValStatus => _valStatusApi;
 
-		public RiotApi(RiotHttpClient riotHttpClient)
-		{
-			_accountApi = new(riotHttpClient);
-			_championApi = new(riotHttpClient);
-			_championMasteryApi = new(riotHttpClient);
-			_clashApi = new(riotHttpClient);
-			_leagueApi = new(riotHttpClient);
-			_lolChallengesApi = new(riotHttpClient);
-			_lolStatusApi = new(riotHttpClient);
-			_lorMatchApi = new(riotHttpClient);
-			_lorRankedApi = new(riotHttpClient);
-			_lorStatusApi = new(riotHttpClient);
-			_matchApi = new(riotHttpClient);
-			_spectatorApi = new(riotHttpClient);
-			_summonerApi = new(riotHttpClient);
-			_tftLeagueApi = new(riotHttpClient);
-			_tftMatchApi = new(riotHttpClient);
-			_tftStatusApi = new(riotHttpClient);
-			_tftSummonerApi = new(riotHttpClient);
-			_valContentApi = new(riotHttpClient);
-			_valMatchApi = new(riotHttpClient);
-			_valRankedApi = new(riotHttpClient);
-			_valStatusApi = new(riotHttpClient);
-			_jsonNodeApi = new(riotHttpClient);
-		}
+        public RiotApi(RiotHttpClient riotHttpClient)
+        {
+            _accountApi = new(riotHttpClient);
+            _championApi = new(riotHttpClient);
+            _championMasteryApi = new(riotHttpClient);
+            _clashApi = new(riotHttpClient);
+            _leagueApi = new(riotHttpClient);
+            _lolChallengesApi = new(riotHttpClient);
+            _lolStatusApi = new(riotHttpClient);
+            _lorMatchApi = new(riotHttpClient);
+            _lorRankedApi = new(riotHttpClient);
+            _lorStatusApi = new(riotHttpClient);
+            _matchApi = new(riotHttpClient);
+            _spectatorApi = new(riotHttpClient);
+            _summonerApi = new(riotHttpClient);
+            _tftLeagueApi = new(riotHttpClient);
+            _tftMatchApi = new(riotHttpClient);
+            _tftStatusApi = new(riotHttpClient);
+            _tftSummonerApi = new(riotHttpClient);
+            _valContentApi = new(riotHttpClient);
+            _valMatchApi = new(riotHttpClient);
+            _valRankedApi = new(riotHttpClient);
+            _valStatusApi = new(riotHttpClient);
+            _jsonNodeApi = new(riotHttpClient);
+        }
 
-		public async Task<T> GetAsync<T>(string route, string path)
-		{
-			JsonNode node = await _jsonNodeApi.GetValueAsync(route, path);
-			return _jsonNodeApi.DeserializeNode<T>(node) ?? throw new NullReferenceException($"Failed to deserialize type {typeof(T)}");
-		}
+        public async Task<T> GetAsync<T>(string route, string path)
+        {
+            JsonNode node = await _jsonNodeApi.GetValueAsync(route, path);
+            return _jsonNodeApi.DeserializeNode<T>(node) ?? throw new NullReferenceException($"Failed to deserialize type {typeof(T)}");
+        }
 
-		public async Task<T> GetAsync<T>(string route, string path, IDictionary<string, string> headers)
-		{
-			JsonNode node = await _jsonNodeApi.GetValueAsync(route, path, headers);
-			return _jsonNodeApi.DeserializeNode<T>(node) ?? throw new NullReferenceException($"Failed to deserialize type {typeof(T)}");
-		}
-	}
+        public async Task<T> GetAsync<T>(string route, string path, IDictionary<string, string> headers)
+        {
+            JsonNode node = await _jsonNodeApi.GetValueAsync(route, path, headers);
+            return _jsonNodeApi.DeserializeNode<T>(node) ?? throw new NullReferenceException($"Failed to deserialize type {typeof(T)}");
+        }
+    }
 }

--- a/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/RiotApi.cs
@@ -4,201 +4,238 @@ using System.Text.Json.Nodes;
 
 namespace BlossomiShymae.RiotBlossom.Api
 {
-    public interface IRiotApi
-    {
-        /// <summary>
-        /// Get the deserialized object, array, or scalar response from endpoint by route and path.
-        /// <para>
-        /// Object
-        /// <code>
-        /// SummonerDto summoner = await client.Riot.GetAsync&lt;SummonerDto&gt;("na1", "/lol/summoner/v4/summoners/by-name/uwuie time");
-        /// </code>
-        /// </para>
-        /// <para>
-        /// Array
-        /// <code>
-        /// List&lt;string&gt; matchIds = await client.Riot.GetAsync&lt;List&lt;string&gt;&gt;("na1", $"/lol/match/v5/matches/by-puuid/{puuid}/ids");
-        /// </code>
-        /// </para>
-        /// <para>
-        /// Scalar
-        /// <code>
-        /// int totalMasteryScore = await client.Riot.GetAsync&lt;int&gt;("na1", $"/lol/champion-mastery/v4/scores/by-summoner/{encryptedSummonerId}");
-        /// </code>
-        /// </para>
-        /// <exception>
-        /// <para>Exceptions</para>
-        /// <para><see cref="NullReferenceException"/></para>
-        /// </exception>
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="route">The raw routing value for request e.g. "na1", "americas", "esports", "ap", etc.</param>
-        /// <param name="path">The path for endpoint e.g. "/lol/status/v4/platform-data".</param>
-        /// <returns></returns>
-        Task<T> GetAsync<T>(string route, string path);
-        /// <summary>
-        /// The API for Account-v1 endpoints.
-        /// </summary>
-        IAccountApi Account { get; }
-        /// <summary>
-        /// The API for Champion-v3 endpoints.
-        /// </summary>
-        IChampionApi Champion { get; }
-        /// <summary>
-        /// The API for Champion-Mastery-v4 endpoints.
-        /// </summary>
-        IChampionMasteryApi ChampionMastery { get; }
-        /// <summary>
-        /// The API for Clash-v1 endpoints.
-        /// </summary>
-        IClashApi Clash { get; }
-        /// <summary>
-        /// The API for League-v4 endpoints.
-        /// </summary>
-        ILeagueApi League { get; }
-        /// <summary>
-        /// The API for Lol-Challenges-v1 endpoints.
-        /// </summary>
-        ILolChallengesApi LolChallenges { get; }
-        /// <summary>
-        /// The API for Lol-Status-v4 endpoint.
-        /// </summary>
-        ILolStatusApi LolStatus { get; }
-        /// <summary>
-        /// The API for Lor-Match-v1 endpoints.
-        /// </summary>
-        ILorMatchApi LorMatch { get; }
-        /// <summary>
-        /// The API for Lor-Ranked-v1 endpoint.
-        /// </summary>
-        ILorRankedApi LorRanked { get; }
-        /// <summary>
-        /// The API for Lor-Status-v1 endpoint.
-        /// </summary>
-        ILorStatusApi LorStatus { get; }
-        /// <summary>
-        /// The API for Match-v5 endpoints.
-        /// </summary>
-        IMatchApi Match { get; }
-        /// <summary>
-        /// The Api for Spectator-v4 endpoints.
-        /// </summary>
-        ISpectatorApi Spectator { get; }
-        /// <summary>
-        /// The API for Summoner-v4 endpoints.
-        /// </summary>
-        ISummonerApi Summoner { get; }
-        /// <summary>
-        /// The API for Tft-League-v1 endpoints.
-        /// </summary>
-        ITftLeagueApi TftLeague { get; }
-        /// <summary>
-        /// The API for Tft-Match-v1 endpoints.
-        /// </summary>
-        ITftMatchApi TftMatch { get; }
-        /// <summary>
-        /// The API for Tft-Status-v1 endpoints.
-        /// </summary>
-        ITftStatusApi TftStatus { get; }
-        /// <summary>
-        /// The API for Tft-Summoner-v1 endpoints.
-        /// </summary>
-        ITftSummonerApi TftSummoner { get; }
-        /// <summary>
-        /// The API for Val-Content-v1 endpoint.
-        /// </summary>
-        IValContentApi ValContent { get; }
-        /// <summary>
-        /// <para>The API for Val-Match-v1 endpoint.</para>
-        /// <para>Note: This API requires an authorized production API key for access!</para>
-        /// </summary>
-        IValMatchApi ValMatch { get; }
-        /// <summary>
-        /// The API for Val-Ranked-v1 endpoint.
-        /// </summary>
-        IValRankedApi ValRanked { get; }
-        /// <summary>
-        /// The API for Val-Status-v1 endpoint.
-        /// </summary>
-        IValStatusApi ValStatus { get; }
-    }
+	public interface IRiotApi
+	{
+		/// <summary>
+		/// Get the deserialized object, array, or scalar response from endpoint by route and path.
+		/// <para>
+		/// Object
+		/// <code>
+		/// SummonerDto summoner = await client.Riot.GetAsync&lt;SummonerDto&gt;("na1", "/lol/summoner/v4/summoners/by-name/uwuie time");
+		/// </code>
+		/// </para>
+		/// <para>
+		/// Array
+		/// <code>
+		/// List&lt;string&gt; matchIds = await client.Riot.GetAsync&lt;List&lt;string&gt;&gt;("na1", $"/lol/match/v5/matches/by-puuid/{puuid}/ids");
+		/// </code>
+		/// </para>
+		/// <para>
+		/// Scalar
+		/// <code>
+		/// int totalMasteryScore = await client.Riot.GetAsync&lt;int&gt;("na1", $"/lol/champion-mastery/v4/scores/by-summoner/{encryptedSummonerId}");
+		/// </code>
+		/// </para>
+		/// <exception>
+		/// <para>Exceptions</para>
+		/// <para><see cref="NullReferenceException"/></para>
+		/// </exception>
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="route">The raw routing value for request e.g. "na1", "americas", "esports", "ap", etc.</param>
+		/// <param name="path">The path for endpoint e.g. "/lol/status/v4/platform-data".</param>
+		/// <returns></returns>
+		Task<T> GetAsync<T>(string route, string path);
+		/// <summary>
+		/// Get the deserialized object, array, or scalar response from endpoint by route and path with applied headers.
+		/// <para>
+		/// Object
+		/// <code>
+		/// SummonerDto summoner = await client.Riot.GetAsync&lt;SummonerDto&gt;("na1", "/lol/summoner/v4/summoners/by-name/uwuie time");
+		/// </code>
+		/// </para>
+		/// <para>
+		/// Array
+		/// <code>
+		/// List&lt;string&gt; matchIds = await client.Riot.GetAsync&lt;List&lt;string&gt;&gt;("na1", $"/lol/match/v5/matches/by-puuid/{puuid}/ids");
+		/// </code>
+		/// </para>
+		/// <para>
+		/// Scalar
+		/// <code>
+		/// int totalMasteryScore = await client.Riot.GetAsync&lt;int&gt;("na1", $"/lol/champion-mastery/v4/scores/by-summoner/{encryptedSummonerId}");
+		/// </code>
+		/// </para>
+		/// <exception>
+		/// <para>Exceptions</para>
+		/// <para><see cref="NullReferenceException"/></para>
+		/// </exception>
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="route">The raw routing value for request e.g. "na1", "americas", "esports", "ap", etc.</param>
+		/// <param name="path">The path for endpoint e.g. "/lol/status/v4/platform-data".</param>
+		/// <param name="headers">The HTTP headers to send with request.</param>
+		/// <returns></returns>
+		Task<T> GetAsync<T>(string route, string path, IDictionary<string, string> headers);
+		/// <summary>
+		/// The API for Account-v1 endpoints.
+		/// </summary>
+		IAccountApi Account { get; }
+		/// <summary>
+		/// The API for Champion-v3 endpoints.
+		/// </summary>
+		IChampionApi Champion { get; }
+		/// <summary>
+		/// The API for Champion-Mastery-v4 endpoints.
+		/// </summary>
+		IChampionMasteryApi ChampionMastery { get; }
+		/// <summary>
+		/// The API for Clash-v1 endpoints.
+		/// </summary>
+		IClashApi Clash { get; }
+		/// <summary>
+		/// The API for League-v4 endpoints.
+		/// </summary>
+		ILeagueApi League { get; }
+		/// <summary>
+		/// The API for Lol-Challenges-v1 endpoints.
+		/// </summary>
+		ILolChallengesApi LolChallenges { get; }
+		/// <summary>
+		/// The API for Lol-Status-v4 endpoint.
+		/// </summary>
+		ILolStatusApi LolStatus { get; }
+		/// <summary>
+		/// The API for Lor-Match-v1 endpoints.
+		/// </summary>
+		ILorMatchApi LorMatch { get; }
+		/// <summary>
+		/// The API for Lor-Ranked-v1 endpoint.
+		/// </summary>
+		ILorRankedApi LorRanked { get; }
+		/// <summary>
+		/// The API for Lor-Status-v1 endpoint.
+		/// </summary>
+		ILorStatusApi LorStatus { get; }
+		/// <summary>
+		/// The API for Match-v5 endpoints.
+		/// </summary>
+		IMatchApi Match { get; }
+		/// <summary>
+		/// The Api for Spectator-v4 endpoints.
+		/// </summary>
+		ISpectatorApi Spectator { get; }
+		/// <summary>
+		/// The API for Summoner-v4 endpoints.
+		/// </summary>
+		ISummonerApi Summoner { get; }
+		/// <summary>
+		/// The API for Tft-League-v1 endpoints.
+		/// </summary>
+		ITftLeagueApi TftLeague { get; }
+		/// <summary>
+		/// The API for Tft-Match-v1 endpoints.
+		/// </summary>
+		ITftMatchApi TftMatch { get; }
+		/// <summary>
+		/// The API for Tft-Status-v1 endpoints.
+		/// </summary>
+		ITftStatusApi TftStatus { get; }
+		/// <summary>
+		/// The API for Tft-Summoner-v1 endpoints.
+		/// </summary>
+		ITftSummonerApi TftSummoner { get; }
+		/// <summary>
+		/// The API for Val-Content-v1 endpoint.
+		/// </summary>
+		IValContentApi ValContent { get; }
+		/// <summary>
+		/// <para>The API for Val-Match-v1 endpoint.</para>
+		/// <para>Note: This API requires an authorized production API key for access!</para>
+		/// </summary>
+		IValMatchApi ValMatch { get; }
+		/// <summary>
+		/// The API for Val-Ranked-v1 endpoint.
+		/// </summary>
+		IValRankedApi ValRanked { get; }
+		/// <summary>
+		/// The API for Val-Status-v1 endpoint.
+		/// </summary>
+		IValStatusApi ValStatus { get; }
+	}
 
-    internal class RiotApi : IRiotApi
-    {
-        private readonly AccountApi _accountApi;
-        private readonly ChampionApi _championApi;
-        private readonly ChampionMasteryApi _championMasteryApi;
-        private readonly ClashApi _clashApi;
-        private readonly LeagueApi _leagueApi;
-        private readonly LolChallengesApi _lolChallengesApi;
-        private readonly LolStatusApi _lolStatusApi;
-        private readonly LorMatchApi _lorMatchApi;
-        private readonly LorRankedApi _lorRankedApi;
-        private readonly LorStatusApi _lorStatusApi;
-        private readonly MatchApi _matchApi;
-        private readonly SpectatorApi _spectatorApi;
-        private readonly SummonerApi _summonerApi;
-        private readonly TftLeagueApi _tftLeagueApi;
-        private readonly TftMatchApi _tftMatchApi;
-        private readonly TftStatusApi _tftStatusApi;
-        private readonly TftSummonerApi _tftSummonerApi;
-        private readonly ValContentApi _valContentApi;
-        private readonly ValMatchApi _valMatchApi;
-        private readonly ValRankedApi _valRankedApi;
-        private readonly ValStatusApi _valStatusApi;
-        private readonly ComposableApi<JsonNode> _jsonNodeApi;
-        public IAccountApi Account => _accountApi;
-        public IChampionApi Champion => _championApi;
-        public IChampionMasteryApi ChampionMastery => _championMasteryApi;
-        public IClashApi Clash => _clashApi;
-        public ILeagueApi League => _leagueApi;
-        public ILolChallengesApi LolChallenges => _lolChallengesApi;
-        public ILolStatusApi LolStatus => _lolStatusApi;
-        public ILorMatchApi LorMatch => _lorMatchApi;
-        public ILorRankedApi LorRanked => _lorRankedApi;
-        public ILorStatusApi LorStatus => _lorStatusApi;
-        public IMatchApi Match => _matchApi;
-        public ISpectatorApi Spectator => _spectatorApi;
-        public ISummonerApi Summoner => _summonerApi;
-        public ITftLeagueApi TftLeague => _tftLeagueApi;
-        public ITftMatchApi TftMatch => _tftMatchApi;
-        public ITftStatusApi TftStatus => _tftStatusApi;
-        public ITftSummonerApi TftSummoner => _tftSummonerApi;
-        public IValContentApi ValContent => _valContentApi;
-        public IValMatchApi ValMatch => _valMatchApi;
-        public IValRankedApi ValRanked => _valRankedApi;
-        public IValStatusApi ValStatus => _valStatusApi;
+	internal class RiotApi : IRiotApi
+	{
+		private readonly AccountApi _accountApi;
+		private readonly ChampionApi _championApi;
+		private readonly ChampionMasteryApi _championMasteryApi;
+		private readonly ClashApi _clashApi;
+		private readonly LeagueApi _leagueApi;
+		private readonly LolChallengesApi _lolChallengesApi;
+		private readonly LolStatusApi _lolStatusApi;
+		private readonly LorMatchApi _lorMatchApi;
+		private readonly LorRankedApi _lorRankedApi;
+		private readonly LorStatusApi _lorStatusApi;
+		private readonly MatchApi _matchApi;
+		private readonly SpectatorApi _spectatorApi;
+		private readonly SummonerApi _summonerApi;
+		private readonly TftLeagueApi _tftLeagueApi;
+		private readonly TftMatchApi _tftMatchApi;
+		private readonly TftStatusApi _tftStatusApi;
+		private readonly TftSummonerApi _tftSummonerApi;
+		private readonly ValContentApi _valContentApi;
+		private readonly ValMatchApi _valMatchApi;
+		private readonly ValRankedApi _valRankedApi;
+		private readonly ValStatusApi _valStatusApi;
+		private readonly ComposableApi<JsonNode> _jsonNodeApi;
+		public IAccountApi Account => _accountApi;
+		public IChampionApi Champion => _championApi;
+		public IChampionMasteryApi ChampionMastery => _championMasteryApi;
+		public IClashApi Clash => _clashApi;
+		public ILeagueApi League => _leagueApi;
+		public ILolChallengesApi LolChallenges => _lolChallengesApi;
+		public ILolStatusApi LolStatus => _lolStatusApi;
+		public ILorMatchApi LorMatch => _lorMatchApi;
+		public ILorRankedApi LorRanked => _lorRankedApi;
+		public ILorStatusApi LorStatus => _lorStatusApi;
+		public IMatchApi Match => _matchApi;
+		public ISpectatorApi Spectator => _spectatorApi;
+		public ISummonerApi Summoner => _summonerApi;
+		public ITftLeagueApi TftLeague => _tftLeagueApi;
+		public ITftMatchApi TftMatch => _tftMatchApi;
+		public ITftStatusApi TftStatus => _tftStatusApi;
+		public ITftSummonerApi TftSummoner => _tftSummonerApi;
+		public IValContentApi ValContent => _valContentApi;
+		public IValMatchApi ValMatch => _valMatchApi;
+		public IValRankedApi ValRanked => _valRankedApi;
+		public IValStatusApi ValStatus => _valStatusApi;
 
-        public RiotApi(RiotHttpClient riotHttpClient)
-        {
-            _accountApi = new(riotHttpClient);
-            _championApi = new(riotHttpClient);
-            _championMasteryApi = new(riotHttpClient);
-            _clashApi = new(riotHttpClient);
-            _leagueApi = new(riotHttpClient);
-            _lolChallengesApi = new(riotHttpClient);
-            _lolStatusApi = new(riotHttpClient);
-            _lorMatchApi = new(riotHttpClient);
-            _lorRankedApi = new(riotHttpClient);
-            _lorStatusApi = new(riotHttpClient);
-            _matchApi = new(riotHttpClient);
-            _spectatorApi = new(riotHttpClient);
-            _summonerApi = new(riotHttpClient);
-            _tftLeagueApi = new(riotHttpClient);
-            _tftMatchApi = new(riotHttpClient);
-            _tftStatusApi = new(riotHttpClient);
-            _tftSummonerApi = new(riotHttpClient);
-            _valContentApi = new(riotHttpClient);
-            _valMatchApi = new(riotHttpClient);
-            _valRankedApi = new(riotHttpClient);
-            _valStatusApi = new(riotHttpClient);
-            _jsonNodeApi = new(riotHttpClient);
-        }
+		public RiotApi(RiotHttpClient riotHttpClient)
+		{
+			_accountApi = new(riotHttpClient);
+			_championApi = new(riotHttpClient);
+			_championMasteryApi = new(riotHttpClient);
+			_clashApi = new(riotHttpClient);
+			_leagueApi = new(riotHttpClient);
+			_lolChallengesApi = new(riotHttpClient);
+			_lolStatusApi = new(riotHttpClient);
+			_lorMatchApi = new(riotHttpClient);
+			_lorRankedApi = new(riotHttpClient);
+			_lorStatusApi = new(riotHttpClient);
+			_matchApi = new(riotHttpClient);
+			_spectatorApi = new(riotHttpClient);
+			_summonerApi = new(riotHttpClient);
+			_tftLeagueApi = new(riotHttpClient);
+			_tftMatchApi = new(riotHttpClient);
+			_tftStatusApi = new(riotHttpClient);
+			_tftSummonerApi = new(riotHttpClient);
+			_valContentApi = new(riotHttpClient);
+			_valMatchApi = new(riotHttpClient);
+			_valRankedApi = new(riotHttpClient);
+			_valStatusApi = new(riotHttpClient);
+			_jsonNodeApi = new(riotHttpClient);
+		}
 
-        public async Task<T> GetAsync<T>(string route, string path)
-        {
-            JsonNode node = await _jsonNodeApi.GetValueAsync(route, path);
-            return _jsonNodeApi.DeserializeNode<T>(node) ?? throw new NullReferenceException($"Failed to deserialize type {typeof(T)}");
-        }
-    }
+		public async Task<T> GetAsync<T>(string route, string path)
+		{
+			JsonNode node = await _jsonNodeApi.GetValueAsync(route, path);
+			return _jsonNodeApi.DeserializeNode<T>(node) ?? throw new NullReferenceException($"Failed to deserialize type {typeof(T)}");
+		}
+
+		public async Task<T> GetAsync<T>(string route, string path, IDictionary<string, string> headers)
+		{
+			JsonNode node = await _jsonNodeApi.GetValueAsync(route, path, headers);
+			return _jsonNodeApi.DeserializeNode<T>(node) ?? throw new NullReferenceException($"Failed to deserialize type {typeof(T)}");
+		}
+	}
 }

--- a/BlossomiShymae.RiotBlossom/Http/RiotHttpClient.cs
+++ b/BlossomiShymae.RiotBlossom/Http/RiotHttpClient.cs
@@ -4,53 +4,53 @@ using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Http
 {
-	internal class RiotHttpClient : IHttpClient
-	{
-		private readonly ComposableHttpClient _composableHttpClient;
-		private readonly string _riotApiKey;
-		private readonly AsyncKeyedLocker<string> _locker = new();
+    internal class RiotHttpClient : IHttpClient
+    {
+        private readonly ComposableHttpClient _composableHttpClient;
+        private readonly string _riotApiKey;
+        private readonly AsyncKeyedLocker<string> _locker = new();
 
-		public RiotHttpClient(ComposableHttpClient composableHttpClient, string riotApiKey)
-		{
-			_composableHttpClient = composableHttpClient;
-			_riotApiKey = riotApiKey;
-		}
+        public RiotHttpClient(ComposableHttpClient composableHttpClient, string riotApiKey)
+        {
+            _composableHttpClient = composableHttpClient;
+            _riotApiKey = riotApiKey;
+        }
 
-		public Task<byte[]> GetByteArrayAsync(string uri)
-		{
-			throw new NotImplementedException();
-		}
+        public Task<byte[]> GetByteArrayAsync(string uri)
+        {
+            throw new NotImplementedException();
+        }
 
-		public async Task<string> GetStringAsync(string uri, string routingValue)
-			=> await GetStringAsync(uri, routingValue, ImmutableDictionary<string, string>.Empty);
+        public async Task<string> GetStringAsync(string uri, string routingValue)
+            => await GetStringAsync(uri, routingValue, ImmutableDictionary<string, string>.Empty);
 
-		internal async Task<string> GetStringAsync(string uri, string routingValue, IDictionary<string, string> headers)
-		{
-			if (string.IsNullOrEmpty(_riotApiKey))
-				throw new MissingApiKeyException("Riot API key is required to access this service");
+        internal async Task<string> GetStringAsync(string uri, string routingValue, IDictionary<string, string> headers)
+        {
+            if (string.IsNullOrEmpty(_riotApiKey))
+                throw new MissingApiKeyException("Riot API key is required to access this service");
 
-			Uri requestUri = new($"https://{routingValue}.api.riotgames.com{uri}");
-			using HttpRequestMessage requestMessage = new(HttpMethod.Get, requestUri);
-			string riotToken = "X-Riot-Token";
-			requestMessage.Headers.Add(riotToken, _riotApiKey);
-			foreach (KeyValuePair<string, string> kvp in headers)
-			{
-				if (kvp.Key.ToLower() != riotToken.ToLower())
-				{
-					requestMessage.Headers.Add(kvp.Key, kvp.Value);
-				}
-				// Override the Riot Token header if user has passed it in
-				else
-				{
-					requestMessage.Headers.Remove(riotToken);
-					requestMessage.Headers.Add(riotToken, kvp.Value);
-				}
-			}
+            Uri requestUri = new($"https://{routingValue}.api.riotgames.com{uri}");
+            using HttpRequestMessage requestMessage = new(HttpMethod.Get, requestUri);
+            string riotToken = "X-Riot-Token";
+            requestMessage.Headers.Add(riotToken, _riotApiKey);
+            foreach (KeyValuePair<string, string> kvp in headers)
+            {
+                if (kvp.Key.ToLower() != riotToken.ToLower())
+                {
+                    requestMessage.Headers.Add(kvp.Key, kvp.Value);
+                }
+                // Override the Riot Token header if user has passed it in
+                else
+                {
+                    requestMessage.Headers.Remove(riotToken);
+                    requestMessage.Headers.Add(riotToken, kvp.Value);
+                }
+            }
 
-			using (await _locker.LockAsync(routingValue))
-			{
-				return await _composableHttpClient.GetStringAsync(requestMessage, routingValue, uri);
-			}
-		}
-	}
+            using (await _locker.LockAsync(routingValue))
+            {
+                return await _composableHttpClient.GetStringAsync(requestMessage, routingValue, uri);
+            }
+        }
+    }
 }

--- a/BlossomiShymae.RiotBlossom/Http/RiotHttpClient.cs
+++ b/BlossomiShymae.RiotBlossom/Http/RiotHttpClient.cs
@@ -1,38 +1,56 @@
 ﻿using AsyncKeyedLock;
 using BlossomiShymae.RiotBlossom.Exception;
+using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Http
 {
-    internal class RiotHttpClient : IHttpClient
-    {
-        private readonly ComposableHttpClient _composableHttpClient;
-        private readonly string _riotApiKey;
-        private readonly AsyncKeyedLocker<string> _locker = new();
+	internal class RiotHttpClient : IHttpClient
+	{
+		private readonly ComposableHttpClient _composableHttpClient;
+		private readonly string _riotApiKey;
+		private readonly AsyncKeyedLocker<string> _locker = new();
 
-        public RiotHttpClient(ComposableHttpClient composableHttpClient, string riotApiKey)
-        {
-            _composableHttpClient = composableHttpClient;
-            _riotApiKey = riotApiKey;
-        }
+		public RiotHttpClient(ComposableHttpClient composableHttpClient, string riotApiKey)
+		{
+			_composableHttpClient = composableHttpClient;
+			_riotApiKey = riotApiKey;
+		}
 
-        public Task<byte[]> GetByteArrayAsync(string uri)
-        {
-            throw new NotImplementedException();
-        }
+		public Task<byte[]> GetByteArrayAsync(string uri)
+		{
+			throw new NotImplementedException();
+		}
 
-        public async Task<string> GetStringAsync(string uri, string routingValue)
-        {
-            if (string.IsNullOrEmpty(_riotApiKey))
-                throw new MissingApiKeyException("Riot API key is required to access this service");
+		public async Task<string> GetStringAsync(string uri, string routingValue)
+			=> await GetStringAsync(uri, routingValue, ImmutableDictionary<string, string>.Empty);
 
-            Uri requestUri = new($"https://{routingValue}.api.riotgames.com{uri}");
-            using HttpRequestMessage requestMessage = new(HttpMethod.Get, requestUri);
-            requestMessage.Headers.Add("X-Riot-Token", _riotApiKey);
+		internal async Task<string> GetStringAsync(string uri, string routingValue, IDictionary<string, string> headers)
+		{
+			if (string.IsNullOrEmpty(_riotApiKey))
+				throw new MissingApiKeyException("Riot API key is required to access this service");
 
-            using (await _locker.LockAsync(routingValue))
-            {
-                return await _composableHttpClient.GetStringAsync(requestMessage, routingValue, uri);
-            }
-        }
-    }
+			Uri requestUri = new($"https://{routingValue}.api.riotgames.com{uri}");
+			using HttpRequestMessage requestMessage = new(HttpMethod.Get, requestUri);
+			string riotToken = "X-Riot-Token";
+			requestMessage.Headers.Add(riotToken, _riotApiKey);
+			foreach (KeyValuePair<string, string> kvp in headers)
+			{
+				if (kvp.Key.ToLower() != riotToken.ToLower())
+				{
+					requestMessage.Headers.Add(kvp.Key, kvp.Value);
+				}
+				// Override the Riot Token header if user has passed it in
+				else
+				{
+					requestMessage.Headers.Remove(riotToken);
+					requestMessage.Headers.Add(riotToken, kvp.Value);
+				}
+			}
+
+			using (await _locker.LockAsync(routingValue))
+			{
+				return await _composableHttpClient.GetStringAsync(requestMessage, routingValue, uri);
+			}
+		}
+	}
 }

--- a/BlossomiShymae.RiotBlossomDocs/content/4.fundamentals/0.api-interfaces.md
+++ b/BlossomiShymae.RiotBlossomDocs/content/4.fundamentals/0.api-interfaces.md
@@ -32,20 +32,48 @@ This means that you will likely have breaking changes for the implemented interf
 
 The Riot Games interface (`Riot`) is denoted by [`IRiotApi`](https://github.com/BlossomiShymae/RiotBlossom/blob/master/BlossomiShymae.RiotBlossom/Api/RiotApi.cs).
 
+### The manual driver
+
 It is possible to make a low-level request via the `GetAsync` method!
 
 ```csharp
-Task<T> GetAsync<T>(string route, string path)
+Task<T> GetAsync<T>(string route, string path);
 ```
 
 This will still take full advantage of the Riot middleware plugin system features (limiting, caching, and retrying if you have them set). Just provide a type for JSON deserialization! 
+
 ( つ•̀ω•́)つ
 
 ```csharp
-// With great power comes great responsibility... OwO
-var summoner = await client.Riot
-    .GetAsync<SummonerDto>("na1", "/lol/summoner/v4/summoners/by-name/uwuie time");
+var summoner = await client.Riot.GetAsync<SummonerDto>("na1", "/lol/summoner/v4/summoners/by-name/uwuie time");
 ```
+
+::alert{type=warning}
+**Oh noes** :br
+:br
+With great power comes great responsibility. Be sure that any path you use is correct!
+::
+
+---
+
+:badge[Added in 1.2.0]
+
+HTTP headers can also be passed. As long as it implements `IDictionary<string, string>`!
+
+```csharp
+Task<T> GetAsync<T>(string route, string path, IDictionary<string, string> headers);
+```
+
+This should allow the use of any RSO endpoints!
+
+```csharp
+var summoner = await client.Riot.GetAsync<SummonerDto>("na1", "/lol/summoner/v4/summoners/me", new Dictionary<string, string> 
+{
+    { "Authorization", "Bearer token example"}
+});
+```
+
+---
 
 The Riot Games minor interfaces correspond to endpoints provided by the Riot Games 
 API!

--- a/BlossomiShymae.RiotBlossomTests/Api/RiotApiTests.cs
+++ b/BlossomiShymae.RiotBlossomTests/Api/RiotApiTests.cs
@@ -31,6 +31,18 @@ namespace BlossomiShymae.RiotBlossomTests.Api
         }
 
         [TestMethod()]
+        [ExpectedException(typeof(HttpRequestException))]
+        public async Task Api_WithBadHeaders_ShouldThrowException()
+        {
+            IRiotBlossomClient client = StubConfig.Client;
+
+            await client.Riot.GetAsync<SummonerDto>("na1", "/lol/summoner/v4/summoners/by-name/uwuie time", new Dictionary<string, string>
+            {
+                { "X-Riot-Token", "Pwease give me 403, hehe!" }
+            });
+        }
+
+        [TestMethod()]
         public async Task Api_WithObjectType_ShouldReturnTypedObject()
         {
             IRiotBlossomClient client = StubConfig.Client;


### PR DESCRIPTION
Resolves #18 ! :>

# Features

- **Api.Riot**: Add `GetAsync` overload that allows passing HTTP headers (f11c14c36f094eb5e63c063029ab8061b1f5741e)