### PR TITLE
Add `GetAsync` for CommunityDragon interface

### DIFF
--- a/BlossomiShymae.RiotBlossom/Api/CommunityDragonApi.cs
+++ b/BlossomiShymae.RiotBlossom/Api/CommunityDragonApi.cs
@@ -3,11 +3,20 @@ using BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Item;
 using BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Perk;
 using BlossomiShymae.RiotBlossom.Http;
 using System.Collections.Immutable;
+using System.Text.Json.Nodes;
 
 namespace BlossomiShymae.RiotBlossom.Api
 {
     public interface ICommunityDragonApi
     {
+        /// <summary>
+        /// Get the deserialized object, array, or scalar response from CommunityDragon RAW path.
+        /// </summary>
+        /// <exception cref="NullReferenceException"></exception>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        Task<T> GetAsync<T>(string path);
         /// <summary>
         /// Get a League champion by ID from the latest game data.
         /// </summary>
@@ -54,6 +63,7 @@ namespace BlossomiShymae.RiotBlossom.Api
         private readonly ComposableApi<Champion> _championApi;
         private readonly ComposableApi<List<PerkRune>> _perkRunesApi;
         private readonly ComposableApi<byte[]> _byteArrayApi;
+        private readonly ComposableApi<JsonNode> _jsonNodeApi;
 
         public CommunityDragonApi(CommunityDragonHttpClient cDragonHttpClient)
         {
@@ -61,6 +71,7 @@ namespace BlossomiShymae.RiotBlossom.Api
             _championApi = new(cDragonHttpClient);
             _perkRunesApi = new(cDragonHttpClient);
             _byteArrayApi = new(cDragonHttpClient);
+            _jsonNodeApi = new(cDragonHttpClient);
         }
 
         public async Task<Item?> GetItemByIdAsync(int id)
@@ -88,5 +99,11 @@ namespace BlossomiShymae.RiotBlossom.Api
 
         public async Task<byte[]> GetProfileIconByteArrayByIdAsync(int id)
             => await _byteArrayApi.GetByteArrayAsync(string.Format(s_profileIconUri, id));
+
+        public async Task<T> GetAsync<T>(string path)
+        {
+            JsonNode node = await _jsonNodeApi.GetValueAsync(path);
+            return _jsonNodeApi.DeserializeNode<T>(node) ?? throw new NullReferenceException($"Failed to deserialize type {typeof(T)}");
+        }
     }
 }

--- a/BlossomiShymae.RiotBlossomDocs/content/4.fundamentals/0.api-interfaces.md
+++ b/BlossomiShymae.RiotBlossomDocs/content/4.fundamentals/0.api-interfaces.md
@@ -172,6 +172,8 @@ The CommunityDragon interface (`CommunityDragon`) is denoted by [`ICommunityDrag
 
 ### The manual driver
 
+:badge[Added in 1.2.0]
+
 We can make a low-level request via the `GetAsync` method!
 
 ```csharp

--- a/BlossomiShymae.RiotBlossomDocs/content/4.fundamentals/0.api-interfaces.md
+++ b/BlossomiShymae.RiotBlossomDocs/content/4.fundamentals/0.api-interfaces.md
@@ -169,3 +169,19 @@ The DataDragon interface (`DataDragon`) is denoted by [`IDataDragonApi`](https:/
 ## The CommunityDragon interface
 
 The CommunityDragon interface (`CommunityDragon`) is denoted by [`ICommunityDragonApi`](https://github.com/BlossomiShymae/RiotBlossom/blob/master/BlossomiShymae.RiotBlossom/Api/CommunityDragonApi.cs).
+
+### The manual driver
+
+We can make a low-level request via the `GetAsync` method!
+
+```csharp
+Task<T> GetAsync<T>(string path);
+```
+
+As always, this will take full advantage of the Riot middleware plugin system features (limiting, caching, and retrying if you have them set). Just provide a type for JSON deserialization! 
+
+⌒°(ᴖ◡ᴖ)°⌒
+
+```csharp
+var champion = await client.CommunityDragon.GetAsync<Champion>("/latest/plugins/rcp-be-lol-game-data/global/default/v1/champions/887.json");
+```

--- a/BlossomiShymae.RiotBlossomTests/Api/CommunityDragonApiTests.cs
+++ b/BlossomiShymae.RiotBlossomTests/Api/CommunityDragonApiTests.cs
@@ -74,5 +74,25 @@ namespace BlossomiShymae.RiotBlossomTests.Api
 
             Assert.IsTrue(profileIcon.Length > 0);
         }
+
+        [TestMethod()]
+        public async Task Api_WithObjectType_ShouldReturnTypeObject()
+        {
+            IRiotBlossomClient client = StubConfig.Client;
+
+            Champion champion = await client.CommunityDragon.GetAsync<Champion>("/latest/plugins/rcp-be-lol-game-data/global/default/v1/champions/887.json");
+
+            Assert.IsInstanceOfType(champion, typeof(Champion));
+        }
+
+        [TestMethod()]
+        public async Task Api_WithArrayType_ShouldReturnArrayObject()
+        {
+            IRiotBlossomClient client = StubConfig.Client;
+
+            List<Item> items = await client.CommunityDragon.GetAsync<List<Item>>("/latest/plugins/rcp-be-lol-game-data/global/default/v1/items.json");
+
+            Assert.IsTrue(items.Count > 0);
+        }
     }
 }


### PR DESCRIPTION
Resolves #17 ! 

# Features
- **Api.CommunityDragon**: Add `GetAsync` method for low-level requests (4262f72a249bd29d7037bbb0d7c9f63b3db03724)