### PR TITLE
Add abstract data object for `Dto` namespace

### DIFF
--- a/BlossomiShymae.RiotBlossom/Core/PrettyPrinter.cs
+++ b/BlossomiShymae.RiotBlossom/Core/PrettyPrinter.cs
@@ -16,19 +16,24 @@ namespace BlossomiShymae.RiotBlossom.Core
         };
 
         /// <summary>
-        /// <para>Get the pretty string of object, hehe!</para>
+        /// <para>Get the pretty string of object with manual class name, hehe!</para>
         /// <para>Note: Field names will be printed into camel case or into JsonPropertyName attribute.</para>
         /// </summary>
         /// <exception cref="NotSupportedException"></exception>
         /// <param name="obj"></param>
+        /// <param name="className"></param>
         /// <returns></returns>
-        public static string GetString<T>(T obj) where T : notnull
+        public static string GetString<T>(T obj, string? className) where T : notnull
         {
             StringBuilder sb = new();
             System.Type type = typeof(T);
-            sb.Append(type.Name);
-            if (type.IsGenericType)
+            if (className != null)
             {
+                sb.Append(className);
+            }
+            else if (type.IsGenericType)
+            {
+                sb.Append(type.Name);
                 sb.Append('[');
                 System.Type[] typeArguments = type.GetGenericArguments();
                 for (int i = 0; i < typeArguments.Length; i++)
@@ -44,5 +49,15 @@ namespace BlossomiShymae.RiotBlossom.Core
 
             return sb.ToString();
         }
+
+        /// <summary>
+        /// <para>Get the pretty string of object, hehe!</para>
+        /// <para>Note: Field names will be printed into camel case or into JsonPropertyName attribute.</para>
+        /// </summary>
+        /// <exception cref="NotSupportedException"></exception>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public static string GetString<T>(T obj) where T : notnull
+            => GetString(obj, null);
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Champion.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Champion.cs
@@ -1,12 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Champion
+    public record Champion : DataObject<Champion>
     {
         public int Id { get; init; }
         public string Name { get; init; } = default!;
@@ -24,10 +23,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
         public ImmutableList<Skin> Skins { get; init; } = ImmutableList<Skin>.Empty;
         public Passive Passive { get; init; } = new();
         public ImmutableList<Spell> Spells { get; init; } = ImmutableList<Spell>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Chroma.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Chroma.cs
@@ -1,12 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Chroma
+    public record Chroma : DataObject<Chroma>
     {
         public int Id { get; init; }
         public string Name { get; init; } = default!;
@@ -14,10 +13,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
         public ImmutableList<string> Colors { get; init; } = ImmutableList<string>.Empty;
         public ImmutableList<ChromaDescription> Descriptions { get; init; } = ImmutableList<ChromaDescription>.Empty;
         public ImmutableList<ChromaRarity> Rarities { get; init; } = ImmutableList<ChromaRarity>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/ChromaDescription.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/ChromaDescription.cs
@@ -1,18 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
+﻿namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record ChromaDescription
+    public record ChromaDescription : DataObject<ChromaDescription>
     {
         public string Region { get; init; } = default!;
         public string Description { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/ChromaRarity.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/ChromaRarity.cs
@@ -1,18 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
+﻿namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record ChromaRarity
+    public record ChromaRarity : DataObject<ChromaRarity>
     {
         public string Region { get; init; } = default!;
         public int Rarity { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Passive.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Passive.cs
@@ -1,21 +1,14 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
+﻿namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Passive
+    public record Passive : DataObject<Passive>
     {
         public string Name { get; init; } = default!;
         public string AbilityIconPath { get; init; } = default!;
         public string AbilityVideoPath { get; init; } = default!;
         public string AbilityVideoImagePath { get; init; } = default!;
         public string Description { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/PlaystyleInfo.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/PlaystyleInfo.cs
@@ -1,21 +1,14 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
+﻿namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record PlaystyleInfo
+    public record PlaystyleInfo : DataObject<PlaystyleInfo>
     {
         public int Damage { get; init; }
         public int Durability { get; init; }
         public int CrowdControl { get; init; }
         public int Mobility { get; init; }
         public int Utility { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Skin.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Skin.cs
@@ -1,12 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Skin
+    public record Skin : DataObject<Skin>
     {
         public int Id { get; init; }
         public bool IsBase { get; init; }
@@ -28,10 +27,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
         public string? RarityGemPath { get; init; }
         public ImmutableList<SkinLine>? SkinLines { get; init; }
         public string Description { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/SkinLine.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/SkinLine.cs
@@ -1,17 +1,10 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
+﻿namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record SkinLine
+    public record SkinLine : DataObject<SkinLine>
     {
         public int Id { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Spell.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/Spell.cs
@@ -1,12 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Spell
+    public record Spell : DataObject<Spell>
     {
         public string SpellKey { get; init; } = default!;
         public string Name { get; init; } = default!;
@@ -23,10 +22,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
         public object EffectAmounts { get; init; } = default!;
         public object Ammo { get; init; } = default!;
         public int MaxLevel { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/TacticalInfo.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Champion/TacticalInfo.cs
@@ -1,19 +1,12 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
+﻿namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record TacticalInfo
+    public record TacticalInfo : DataObject<TacticalInfo>
     {
         public int Style { get; init; }
         public int Difficulty { get; init; }
         public string DamageType { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Item/Item.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Item/Item.cs
@@ -1,12 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Item
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Item
+    public record Item : DataObject<Item>
     {
         public int Id { get; init; }
         public string Name { get; init; } = default!;
@@ -26,10 +25,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Item
         public int Price { get; init; }
         public int PriceTotal { get; init; }
         public string IconPath { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Perk/PerkRune.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/CommunityDragon/Perk/PerkRune.cs
@@ -1,12 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Perk
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record PerkRune
+    public record PerkRune : DataObject<PerkRune>
     {
         public int Id { get; init; }
         public string Name { get; init; } = default!;
@@ -18,10 +17,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.CommunityDragon.Perk
         public string IconPath { get; init; } = default!;
         public ImmutableList<string> EndOfGameStatDescs { get; init; } = ImmutableList<string>.Empty;
         public ImmutableDictionary<string, double> RecommendationDescriptorAttributes { get; init; } = ImmutableDictionary<string, double>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Champion.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Champion.cs
@@ -1,12 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Champion
+    public record Champion : DataObject<Champion>
     {
         public string Id { get; init; } = default!;
         public string Key { get; init; } = default!;
@@ -25,10 +24,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
         public ImmutableList<Spell> Spells { get; init; } = ImmutableList<Spell>.Empty;
         public Passive Passive { get; init; } = new();
         public object? Recommended { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Image.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Image.cs
@@ -1,11 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
+﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Image
+    public record Image : DataObject<Image>
     {
         public string Full { get; init; } = default!;
         public string Sprite { get; init; } = default!;
@@ -14,10 +12,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
         public int Y { get; init; }
         public int W { get; init; }
         public int H { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Info.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Info.cs
@@ -1,20 +1,13 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
+﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Info
+    public record Info : DataObject<Info>
     {
         public int Attack { get; init; }
         public int Defense { get; init; }
         public int Magic { get; init; }
         public int Difficulty { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Leveltip.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Leveltip.cs
@@ -1,19 +1,13 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Leveltip
+    public record Leveltip : DataObject<Leveltip>
     {
         public ImmutableList<string> Label { get; init; } = ImmutableList<string>.Empty;
         public ImmutableList<string> Effect { get; init; } = ImmutableList<string>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Passive.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Passive.cs
@@ -1,19 +1,12 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
+﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Passive
+    public record Passive : DataObject<Passive>
     {
         public string Name { get; init; } = default!;
         public string Description { get; init; } = default!;
         public Image Image { get; init; } = new();
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Skin.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Skin.cs
@@ -1,20 +1,13 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
+﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Skin
+    public record Skin : DataObject<Skin>
     {
         public string Id { get; init; } = default!;
         public int Num { get; init; }
         public string Name { get; init; } = default!;
         public bool Chromas { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Spell.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Spell.cs
@@ -1,12 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Spell
+    public record Spell : DataObject<Spell>
     {
         public string Id { get; init; } = default!;
         public string Name { get; init; } = default!;
@@ -28,10 +27,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
         public string RangeBurn { get; init; } = default!;
         public Image Image { get; init; } = new();
         public string Resource { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Stats.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Champion/Stats.cs
@@ -1,11 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
+﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Stats
+    public record Stats : DataObject<Stats>
     {
         public double Hp { get; init; }
         public double Hpperlevel { get; init; }
@@ -27,10 +25,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Champion
         public double Attackdamageperlevel { get; init; }
         public double Attackspeedperlevel { get; init; }
         public double Attackspeed { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Item/Gold.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Item/Gold.cs
@@ -1,20 +1,13 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Item
+﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Item
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Gold
+    public record Gold : DataObject<Gold>
     {
         public int Base { get; init; }
         public int Total { get; init; }
         public int Sell { get; init; }
         public bool Purchasable { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Item/Image.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Item/Image.cs
@@ -1,11 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Item
+﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Item
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Image
+    public record Image : DataObject<Image>
     {
         public string Full { get; init; } = default!;
         public string Sprite { get; init; } = default!;
@@ -14,10 +12,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Item
         public int Y { get; init; }
         public int W { get; init; }
         public int H { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Item/Item.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Item/Item.cs
@@ -1,12 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Item
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Item
+    public record Item : DataObject<Item>
     {
         public string Name { get; init; } = default!;
         public Rune Rune { get; init; } = new();
@@ -29,10 +28,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Item
         public ImmutableDictionary<string, double> Stats { get; init; } = ImmutableDictionary<string, double>.Empty;
         public ImmutableList<string> Tags { get; init; } = ImmutableList<string>.Empty;
         public ImmutableDictionary<int, bool> Maps { get; init; } = ImmutableDictionary<int, bool>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Item/Rune.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Item/Rune.cs
@@ -1,19 +1,12 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Item
+﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Item
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Rune
+    public record Rune : DataObject<Rune>
     {
         public bool IsRune { get; init; }
         public int Tier { get; init; }
         public string Type { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Perk/PerkRune.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Perk/PerkRune.cs
@@ -1,11 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Perk
+﻿namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Perk
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record PerkRune
+    public record PerkRune : DataObject<PerkRune>
     {
         public int Id { get; init; }
         public string Key { get; init; } = default!;
@@ -13,10 +11,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Perk
         public string Name { get; init; } = default!;
         public string ShortDesc { get; init; } = default!;
         public string LongDesc { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Perk/PerkStyle.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Perk/PerkStyle.cs
@@ -1,22 +1,16 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Perk
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record PerkStyle
+    public record PerkStyle : DataObject<PerkStyle>
     {
         public int Id { get; init; }
         public string Key { get; init; } = default!;
         public string Icon { get; init; } = default!;
         public string Name { get; init; } = default!;
         public ImmutableList<Slot> Slots { get; init; } = ImmutableList<Slot>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataDragon/Perk/Slot.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataDragon/Perk/Slot.cs
@@ -1,18 +1,12 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.DataDragon.Perk
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Slot
+    public record Slot : DataObject<Slot>
     {
         public ImmutableList<PerkRune> Runes { get; init; } = ImmutableList<PerkRune>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataObject.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataObject.cs
@@ -2,20 +2,17 @@
 
 namespace BlossomiShymae.RiotBlossom.Dto
 {
-    public abstract record DataObject<T> where T : notnull
+    public abstract record DataObject<T>
     {
-        private T? _data;
-        protected T Data
+        internal static class Helper<U>
         {
-            get => _data ?? throw new InvalidOperationException($"{nameof(Data)} property must be initialized for {typeof(T)}!");
-            set => _data = value;
+            private static readonly string s_typeName = typeof(U).Name;
+            public static string Name => s_typeName;
         }
 
-        public DataObject() { }
-
-        public override string ToString()
+        public sealed override string ToString()
         {
-            return PrettyPrinter.GetString(Data);
+            return PrettyPrinter.GetString(this, Helper<T>.Name);
         }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/DataObject.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataObject.cs
@@ -1,0 +1,21 @@
+﻿using BlossomiShymae.RiotBlossom.Core;
+
+namespace BlossomiShymae.RiotBlossom.Dto
+{
+    public abstract record DataObject<T> where T : notnull
+    {
+        private T? _data;
+        protected T Data
+        {
+            get => _data ?? throw new InvalidOperationException($"{nameof(Data)} property must be initialized for {typeof(T)}!");
+            set => _data = value;
+        }
+
+        public DataObject() { }
+
+        public override string ToString()
+        {
+            return PrettyPrinter.GetString(Data);
+        }
+    }
+}

--- a/BlossomiShymae.RiotBlossom/Dto/DataObject.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/DataObject.cs
@@ -4,7 +4,7 @@ namespace BlossomiShymae.RiotBlossom.Dto
 {
     public abstract record DataObject<T>
     {
-        internal static class Helper<U>
+        private static class Helper<U>
         {
             private static readonly string s_typeName = typeof(U).Name;
             public static string Name => s_typeName;

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Ability.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Ability.cs
@@ -1,12 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Ability
+    public record Ability : DataObject<Ability>
     {
         public string? Name { get; init; }
         public string? Icon { get; init; }
@@ -36,10 +35,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
         public string? CastTime { get; init; }
         public string? EffectRadius { get; init; }
         public string? TargetRange { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/AttributeRatings.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/AttributeRatings.cs
@@ -1,11 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
+﻿namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record AttributeRatings
+    public record AttributeRatings : DataObject<AttributeRatings>
     {
         public int Damage { get; init; }
         public int Toughness { get; init; }
@@ -17,10 +15,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
         public int Defense { get; init; }
         public int Magic { get; init; }
         public int Difficulty { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Champion.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Champion.cs
@@ -1,12 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Champion
+    public record Champion : DataObject<Champion>
     {
         public int Id { get; init; }
         public string? Key { get; init; }
@@ -28,10 +27,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
         public string? Lore { get; init; }
         public string? Faction { get; init; }
         public ImmutableList<Skin> Skins { get; init; } = ImmutableList<Skin>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Chroma.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Chroma.cs
@@ -1,12 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Chroma
+    public record Chroma : DataObject<Chroma>
     {
         public string? Name { get; init; }
         public long Id { get; init; }
@@ -14,10 +13,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
         public ImmutableList<string> Colors { get; init; } = ImmutableList<string>.Empty;
         public ImmutableList<DescriptionDto> Descriptions { get; init; } = ImmutableList<DescriptionDto>.Empty;
         public ImmutableList<Rarities> Rarities { get; init; } = ImmutableList<Rarities>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Cooldown.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Cooldown.cs
@@ -1,19 +1,13 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Cooldown
+    public record Cooldown : DataObject<Cooldown>
     {
         public ImmutableList<Modifier> Modifiers { get; init; } = ImmutableList<Modifier>.Empty;
         public bool AffectedByCdr { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Cost.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Cost.cs
@@ -1,18 +1,12 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Cost
+    public record Cost : DataObject<Cost>
     {
         public ImmutableList<Modifier> Modifiers { get; init; } = ImmutableList<Modifier>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/DescriptionDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/DescriptionDto.cs
@@ -1,18 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
+﻿namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record DescriptionDto
+    public record DescriptionDto : DataObject<DescriptionDto>
     {
         public string? Description { get; init; }
         public string? Region { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Effect.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Effect.cs
@@ -1,19 +1,13 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Effect
+    public record Effect : DataObject<Effect>
     {
         public string? Description { get; init; }
         public ImmutableList<Leveling> Leveling { get; init; } = ImmutableList<Leveling>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Leveling.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Leveling.cs
@@ -1,19 +1,13 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Leveling
+    public record Leveling : DataObject<Leveling>
     {
         public string? Attribute { get; init; }
         public ImmutableList<Modifier> Modifiers { get; init; } = ImmutableList<Modifier>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Modifier.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Modifier.cs
@@ -1,19 +1,13 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Modifier
+    public record Modifier : DataObject<Modifier>
     {
         public ImmutableList<double> Values { get; init; } = ImmutableList<double>.Empty;
         public ImmutableList<string> Units { get; init; } = ImmutableList<string>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Price.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Price.cs
@@ -1,19 +1,12 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
+﻿namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Price
+    public record Price : DataObject<Price>
     {
         public int BlueEssence { get; init; }
         public int Rp { get; init; }
         public int SaleRp { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Rarities.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Rarities.cs
@@ -1,18 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
+﻿namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Rarities
+    public record Rarities : DataObject<Rarities>
     {
         public int? Rarity { get; init; }
         public string? Region { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Skin.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Skin.cs
@@ -7,7 +7,7 @@ namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Skin
+    public record Skin : DataObject<Skin>
     {
         public string? Name { get; init; }
         public int Id { get; init; }
@@ -36,10 +36,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
         public bool NewQuotes { get; init; }
         public ImmutableList<string> VoiceActor { get; init; } = ImmutableList<string>.Empty;
         public ImmutableList<string> SplashArtist { get; init; } = ImmutableList<string>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Stats.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Champion/Stats.cs
@@ -1,12 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Common;
+﻿using BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Common;
 
 namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Stats
+    public record Stats : DataObject<Stats>
     {
         public Stat Health { get; init; } = new();
         public Stat HealthRegen { get; init; } = new();
@@ -36,10 +35,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Champion
         public Stat UrfDamageDealt { get; init; } = new();
         public Stat UrfHealing { get; init; } = new();
         public Stat UrfShielding { get; init; } = new();
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Common/Stat.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Common/Stat.cs
@@ -6,7 +6,7 @@ namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Common
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Stat
+    public record Stat : DataObject<Stat>
     {
         [JsonConverter(typeof(DoubleJsonConverter))]
         public double Flat { get; init; }
@@ -15,10 +15,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Common
         public double PercentPerLevel { get; init; }
         public double PercentBase { get; init; }
         public double PercentBonus { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Item/Active.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Item/Active.cs
@@ -1,21 +1,14 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Item
+﻿namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Item
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Active
+    public record Active : DataObject<Active>
     {
         public bool Unique { get; init; }
         public string? Name { get; init; }
         public string? Effects { get; init; }
         public int Range { get; init; }
         public float Cooldown { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Item/Item.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Item/Item.cs
@@ -1,12 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Item
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Item
+    public record Item : DataObject<Item>
     {
         public string? Name { get; init; }
         public int Id { get; init; }
@@ -27,10 +26,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Item
         public Stats Stats { get; init; } = new();
         public Shop Shop { get; init; } = new();
         public bool IconOverlay { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Item/Passive.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Item/Passive.cs
@@ -6,7 +6,7 @@ namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Item
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Passive
+    public record Passive : DataObject<Passive>
     {
         public bool Unique { get; init; }
         public bool Mythic { get; init; }
@@ -16,10 +16,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Item
         [JsonConverter(typeof(StringJsonConverter))]
         public string? Cooldown { get; init; }
         public Stats Stats { get; init; } = new();
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Item/Prices.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Item/Prices.cs
@@ -1,19 +1,12 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Item
+﻿namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Item
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Prices
+    public record Prices : DataObject<Prices>
     {
         public int Total { get; init; }
         public int Combined { get; init; }
         public int Sell { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Item/Shop.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Item/Shop.cs
@@ -1,20 +1,14 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Item
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Shop
+    public record Shop : DataObject<Shop>
     {
         public Prices Prices { get; init; } = new();
         public bool Purchasable { get; init; }
         public ImmutableList<string> Tags { get; init; } = ImmutableList<string>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Item/Stats.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/MerakiAnalytics/Item/Stats.cs
@@ -1,12 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Common;
+﻿using BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Common;
 
 namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Item
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Stats
+    public record Stats : DataObject<Stats>
     {
         public Stat AbilityPower { get; init; } = new();
         public Stat Armor { get; init; } = new();
@@ -29,10 +28,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.MerakiAnalytics.Item
         public Stat AbilityHaste { get; init; } = new();
         public Stat Omnivamp { get; init; } = new();
         public Stat Tenacity { get; init; } = new();
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Account/AccountDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Account/AccountDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Account
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Account
 {
-    public record AccountDto
+    public record AccountDto : DataObject<AccountDto>
     {
         /// <summary>
         /// The player UUID associated with account.
@@ -16,10 +14,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Account
         /// The Riot tag line associated with account. May be excluded from response if account does not have it.
         /// </summary>
         public string? TagLine { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Champion/ChampionInfo.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Champion/ChampionInfo.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Champion
 {
-    public record ChampionInfo
+    public record ChampionInfo : DataObject<ChampionInfo>
     {
         /// <summary>
         /// The maximum level the new player champion rotation is available before unlocking the 
@@ -18,10 +17,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Champion
         /// The current free champion rotation pool.
         /// </summary>
         public ImmutableList<int> FreeChampionIds { get; init; } = ImmutableList<int>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ChampionMastery/ChampionMasteryDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ChampionMastery/ChampionMasteryDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ChampionMastery
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ChampionMastery
 {
-    public record ChampionMasteryDto
+    public record ChampionMasteryDto : DataObject<ChampionMasteryDto>
     {
         /// <summary>
         /// The number of points needed to achieve next mastery level. Zero when player has reached
@@ -41,10 +39,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ChampionMastery
         /// The tokens earned for champion at current level. Resets to zero when <see cref="ChampionLevel"/> advances.
         /// </summary>
         public int TokensEarned { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Clash/PlayerDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Clash/PlayerDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
 {
-    public record PlayerDto
+    public record PlayerDto : DataObject<PlayerDto>
     {
         /// <summary>
         /// The encrypted summoner ID of player.
@@ -20,10 +18,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
         /// The assigned role ('CAPTAIN', 'MEMBER').
         /// </summary>
         public string Role { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Clash/TeamDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Clash/TeamDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
 {
-    public record TeamDto
+    public record TeamDto : DataObject<TeamDto>
     {
         /// <summary>
         /// The team ID.
@@ -37,10 +36,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
         /// The current team roster.
         /// </summary>
         public ImmutableList<PlayerDto> Players { get; init; } = ImmutableList<PlayerDto>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Clash/TournamentDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Clash/TournamentDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
 {
-    public record TournamentDto
+    public record TournamentDto : DataObject<TournamentDto>
     {
         /// <summary>
         /// The tournament ID.
@@ -25,10 +24,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
         /// The spanning date the tournament will take place on.
         /// </summary>
         public ImmutableList<TournamentPhaseDto> Schedule { get; init; } = ImmutableList<TournamentPhaseDto>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Clash/TournamentPhaseDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Clash/TournamentPhaseDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
 {
-    public record TournamentPhaseDto
+    public record TournamentPhaseDto : DataObject<TournamentPhaseDto>
     {
         /// <summary>
         /// The tournament phase ID.
@@ -20,10 +18,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Clash
         /// Whether the tournament phase will occur for totes' whatever reason. :3
         /// </summary>
         public bool Cancelled { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/League/LeagueEntryDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/League/LeagueEntryDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
 {
-    public record LeagueEntryDto
+    public record LeagueEntryDto : DataObject<LeagueEntryDto>
     {
         /// <summary>
         /// The league entry ID.
@@ -60,10 +58,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
         /// The current miniseries (rank promotions) the player is involved in.
         /// </summary>
         public MiniSeriesDto? MiniSeries { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/League/LeagueItemDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/League/LeagueItemDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
 {
-    public record LeagueItemDto
+    public record LeagueItemDto : DataObject<LeagueItemDto>
     {
         /// <summary>
         /// The player is new to the division (<see cref="Rank"/>).
@@ -48,10 +46,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
         /// The player encrypted summoner ID.
         /// </summary>
         public string SummonerId { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/League/LeagueListDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/League/LeagueListDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
 {
-    public record LeagueListDto
+    public record LeagueListDto : DataObject<LeagueListDto>
     {
         /// <summary>
         /// The associated league ID.
@@ -25,10 +24,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
         /// The queue type the league is for e.g. "RANKED_SOLO_5x5".
         /// </summary>
         public string Queue { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/League/MiniSeriesDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/League/MiniSeriesDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
 {
-    public record MiniSeriesDto
+    public record MiniSeriesDto : DataObject<MiniSeriesDto>
     {
         /// <summary>
         /// The game losses for miniseries.
@@ -35,10 +33,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.League
         /// The game wins for miniseries.
         /// </summary>
         public int Wins { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/ApexPlayerInfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/ApexPlayerInfoDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
 {
-    public record ApexPlayerInfoDto
+    public record ApexPlayerInfoDto : DataObject<ApexPlayerInfoDto>
     {
         /// <summary>
         /// The encrypted PUUID of apex player.
@@ -16,10 +14,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
         /// The leaderboard position of apex player.
         /// </summary>
         public long Position { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/ChallengeConfigInfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/ChallengeConfigInfoDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
 {
-    public record ChallengeConfigInfoDto
+    public record ChallengeConfigInfoDto : DataObject<ChallengeConfigInfoDto>
     {
         /// <summary>
         /// The challenge ID.
@@ -37,10 +36,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
         /// The map of threshold values for challenge.
         /// </summary>
         public ImmutableDictionary<string, double> Thresholds { get; init; } = ImmutableDictionary<string, double>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/ChallengeInfo.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/ChallengeInfo.cs
@@ -1,21 +1,14 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record ChallengeInfo
+    public record ChallengeInfo : DataObject<ChallengeInfo>
     {
         public long ChallengeId { get; init; }
         public double Percentile { get; init; }
         public string Level { get; init; } = default!;
         public double Value { get; init; }
         public long AchievedTime { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/ChallengePoints.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/ChallengePoints.cs
@@ -1,20 +1,13 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record ChallengePoints
+    public record ChallengePoints : DataObject<ChallengePoints>
     {
         public string Level { get; init; } = default!;
         public double Current { get; init; }
         public double Max { get; init; }
         public double Percentile { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/LocalizedName.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/LocalizedName.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
 {
-    public record LocalizedName
+    public record LocalizedName : DataObject<LocalizedName>
     {
         /// <summary>
         /// The localized description of challenge.
@@ -16,10 +14,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
         /// The localized brief description of challenge.
         /// </summary>
         public string ShortDescription { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/PlayerClientPreferences.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/PlayerClientPreferences.cs
@@ -1,20 +1,14 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record PlayerClientPreferences
+    public record PlayerClientPreferences : DataObject<PlayerClientPreferences>
     {
         public string BannerAccent { get; init; } = default!;
         public string Title { get; init; } = default!;
         public ImmutableList<int> ChallengeIds { get; init; } = ImmutableList<int>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/PlayerInfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolChallenges/PlayerInfoDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
 {
-    public record PlayerInfoDto
+    public record PlayerInfoDto : DataObject<PlayerInfoDto>
     {
         /// <summary>
         /// The list of challenges for player.
@@ -21,10 +20,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolChallenges
         /// The map of challenge point information by category e.g. "TEAMWORK", "EXPERTISE", "IMAGINATION", "VETERANCY", "COLLECTION".
         /// </summary>
         public ImmutableDictionary<string, ChallengePoints> CategoryPoints { get; init; } = ImmutableDictionary<string, ChallengePoints>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolStatus/ContentDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolStatus/ContentDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus
 {
-    public record ContentDto
+    public record ContentDto : DataObject<ContentDto>
     {
         /// <summary>
         /// The locale identifier for content e.g. ("en_US", "de_DE").
@@ -12,10 +10,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus
         /// The text content for incident.
         /// </summary>
         public string Content { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolStatus/PlatformDataDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolStatus/PlatformDataDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus
 {
-    public record PlatformDataDto
+    public record PlatformDataDto : DataObject<PlatformDataDto>
     {
         /// <summary>
         /// The platform data ID e.g. "SG2".
@@ -25,10 +24,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus
         /// The current incidents for platform.
         /// </summary>
         public ImmutableList<StatusDto> Incidents { get; init; } = ImmutableList<StatusDto>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolStatus/StatusDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolStatus/StatusDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus
 {
-    public record StatusDto
+    public record StatusDto : DataObject<StatusDto>
     {
         /// <summary>
         /// The status ID.
@@ -43,10 +42,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus
         /// The platform list affected by this incident e.g. "windows", "macos".
         /// </summary>
         public ImmutableList<string> Platforms { get; init; } = ImmutableList<string>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LolStatus/UpdateDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LolStatus/UpdateDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus
 {
-    public record UpdateDto
+    public record UpdateDto : DataObject<UpdateDto>
     {
         /// <summary>
         /// The update ID.
@@ -35,10 +34,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LolStatus
         /// <example>2023-01-19T02:14:00+00:00</example>
         /// </summary>
         public string UpdatedAt { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/InfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/InfoDto.cs
@@ -1,10 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
 {
-    public record InfoDto
+    public record InfoDto : DataObject<InfoDto>
     {
         /// <summary>
         /// The current game mode. (Legal values: Constructed, Expeditions, Tutorial, and a lot more not documented)
@@ -35,10 +34,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
         /// </summary>
         [JsonPropertyName("total_turn_count")]
         public int TotalTurnCount { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/MatchDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/MatchDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
 {
-    public record MatchDto
+    public record MatchDto : DataObject<MatchDto>
     {
         /// <summary>
         /// The match metadata.
@@ -12,10 +10,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
         /// The match info.
         /// </summary>
         public InfoDto Info { get; init; } = new();
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/MetadataDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/MetadataDto.cs
@@ -1,10 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
 {
-    public record MetadataDto
+    public record MetadataDto : DataObject<MetadataDto>
     {
         /// <summary>
         /// The match data version.
@@ -20,10 +19,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
         /// The list of participant PUUIDs.
         /// </summary>
         public ImmutableList<string> Participants { get; init; } = ImmutableList<string>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/PlayerDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorMatch/PlayerDto.cs
@@ -1,10 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
 {
-    public record PlayerDto
+    public record PlayerDto : DataObject<PlayerDto>
     {
         /// <summary>
         /// The player UUID.
@@ -28,10 +27,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorMatch
         /// </summary>
         [JsonPropertyName("order_of_play")]
         public int OrderOfPlay { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorRanked/LeaderboardDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorRanked/LeaderboardDto.cs
@@ -1,18 +1,12 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorRanked
 {
-    public record LeaderboardDto
+    public record LeaderboardDto : DataObject<LeaderboardDto>
     {
         /// <summary>
         /// The list of players in Master tier.
         /// </summary>
         public ImmutableList<PlayerDto> Players { get; init; } = ImmutableList<PlayerDto>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/LorRanked/PlayerDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/LorRanked/PlayerDto.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorRanked
 {
-    public record PlayerDto
+    public record PlayerDto : DataObject<PlayerDto>
     {
         /// <summary>
         /// The player name.
@@ -20,10 +20,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.LorRanked
         /// </summary>
         [JsonConverter(typeof(IntJsonConverter))]
         public int Lp { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/BanDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/BanDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
-    public record BanDto
+    public record BanDto : DataObject<BanDto>
     {
         /// <summary>
         /// The banned champion ID.
@@ -12,10 +10,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// The pick turn that the ban occured in.
         /// </summary>
         public int PickTurn { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ChampionStats.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ChampionStats.cs
@@ -1,11 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record ChampionStats
+    public record ChampionStats : DataObject<ChampionStats>
     {
         public double AbilityHaste { get; init; }
         public double AbilityPower { get; init; }
@@ -32,10 +30,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         public double PowerMax { get; init; }
         public double PowerRegen { get; init; }
         public double SpellVamp { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/DamageStats.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/DamageStats.cs
@@ -1,11 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record DamageStats
+    public record DamageStats : DataObject<DamageStats>
     {
         public long MagicDamageDone { get; init; }
         public long MagicDamageDoneToChampions { get; init; }
@@ -19,10 +17,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         public long TrueDamageDone { get; init; }
         public long TrueDamageDoneToChampions { get; init; }
         public long TrueDamageTaken { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/Event.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/Event.cs
@@ -1,16 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
-    public record Event
+    public record Event : DataObject<Event>
     {
         public long RealTimestamp { get; init; }
         public long Timestamp { get; init; }
         public string Type { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/Frame.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/Frame.cs
@@ -1,20 +1,14 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Frame
+    public record Frame : DataObject<Frame>
     {
         public ImmutableList<Event> Events { get; init; } = ImmutableList<Event>.Empty;
         public ImmutableDictionary<string, ParticipantFrame> ParticipantFrames { get; init; } = ImmutableDictionary<string, ParticipantFrame>.Empty;
         public long Timestamp { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/InfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/InfoDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
-    public record InfoDto
+    public record InfoDto : DataObject<InfoDto>
     {
         /// <summary>
         /// The Unix timestamp for when the game is created on the game server.
@@ -66,10 +65,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// The tournament code used to generate the match.
         /// </summary>
         public string TournamentCode { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/MatchDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/MatchDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
-    public record MatchDto
+    public record MatchDto : DataObject<MatchDto>
     {
         /// <summary>
         /// The metadata of match.
@@ -12,10 +10,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// The info of match. The yummy part that most developers want. :eyes:
         /// </summary>
         public InfoDto Info { get; init; } = new();
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/MatchTimelineDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/MatchTimelineDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
-    public record MatchTimelineDto
+    public record MatchTimelineDto : DataObject<MatchTimelineDto>
     {
         /// <summary>
         /// The metadata of match.
@@ -12,10 +10,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// The timeline info of match.
         /// </summary>
         public TimelineInfoDto Info { get; init; } = new();
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/MetadataDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/MetadataDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
-    public record MetadataDto
+    public record MetadataDto : DataObject<MetadataDto>
     {
         /// <summary>
         /// The data version of match.
@@ -17,10 +16,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// The list of encrypted PUUIDs for summoners that participated in the match.
         /// </summary>
         public ImmutableList<string> Participants { get; init; } = ImmutableList<string>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ObjectiveDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ObjectiveDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
-    public record ObjectiveDto
+    public record ObjectiveDto : DataObject<ObjectiveDto>
     {
         /// <summary>
         /// Whether team got the first kill for the objective.
@@ -12,10 +10,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// The amount of times this objective was killed.
         /// </summary>
         public int Kills { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ObjectivesDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ObjectivesDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
-    public record ObjectivesDto
+    public record ObjectivesDto : DataObject<ObjectivesDto>
     {
 
         /// <summary>
@@ -29,10 +27,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// The lane, base, and nexus towers for a team.
         /// </summary>
         public ObjectiveDto Tower { get; init; } = new();
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ParticipantDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ParticipantDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
-    public record ParticipantDto
+    public record ParticipantDto : DataObject<ParticipantDto>
     {
         /// <summary>
         /// The player assists.
@@ -494,10 +492,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// UNDOCUMENTED
         /// </summary>
         public bool EligibleForProgression { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ParticipantFrame.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/ParticipantFrame.cs
@@ -1,11 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record ParticipantFrame
+    public record ParticipantFrame : DataObject<ParticipantFrame>
     {
         public ChampionStats ChampionStats { get; init; } = new();
         public long CurrentGold { get; init; }
@@ -19,10 +17,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         public long TimeEnemySpentControlled { get; init; }
         public long TotalGold { get; init; }
         public long Xp { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/PerkStatsDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/PerkStatsDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
-    public record PerkStatsDto
+    public record PerkStatsDto : DataObject<PerkStatsDto>
     {
         /// <summary>
         /// The selected defense perk ID.
@@ -16,10 +14,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// The selected Offense perk ID.
         /// </summary>
         public int Offense { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/PerkStyleDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/PerkStyleDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
-    public record PerkStyleDto
+    public record PerkStyleDto : DataObject<PerkStyleDto>
     {
         /// <summary>
         /// The description of perk style.
@@ -17,10 +16,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// The style ID.
         /// </summary>
         public int Style { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/PerkStyleSelectionDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/PerkStyleSelectionDto.cs
@@ -1,12 +1,10 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     /// <summary>
     /// A perk style selection used for Runes Reforged.
     /// For more details on how these are used, see CommunityDragon <see href="https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/perks.json">perks.json</see>.
     /// </summary>
-    public record PerkStyleSelectionDto
+    public record PerkStyleSelectionDto : DataObject<PerkStyleSelectionDto>
     {
         /// <summary>
         /// The perk ID.
@@ -24,10 +22,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// The third variable used for the end of game stat descriptions.
         /// </summary>
         public int Var3 { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/PerksDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/PerksDto.cs
@@ -1,5 +1,4 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
@@ -7,7 +6,7 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
     /// A game data object that represents selected options in Runes Reforged.
     /// See CommunityDragon <see href="https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/perks.json">perks.json</see>.
     /// </summary>
-    public record PerksDto
+    public record PerksDto : DataObject<PerksDto>
     {
         /// <summary>
         /// The selected stat perks for a player.
@@ -17,10 +16,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// The selected perk styles for a player.
         /// </summary>
         public ImmutableList<PerkStyleDto> Styles { get; init; } = ImmutableList<PerkStyleDto>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/Position.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/Position.cs
@@ -1,18 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record Position
+    public record Position : DataObject<Position>
     {
         public double X { get; init; }
         public double Y { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/TeamDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/TeamDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
-    public record TeamDto
+    public record TeamDto : DataObject<TeamDto>
     {
         /// <summary>
         /// The champions that a team has banned in Draft Pick.
@@ -21,10 +20,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
         /// Whether a team has winned a match e.g. destroyed the enemy nexus.
         /// </summary>
         public bool Win { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/TimelineInfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/TimelineInfoDto.cs
@@ -1,21 +1,15 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record TimelineInfoDto
+    public record TimelineInfoDto : DataObject<TimelineInfoDto>
     {
         public long FrameInterval { get; init; }
         public ImmutableList<Frame> Frames { get; init; } = ImmutableList<Frame>.Empty;
         public long GameId { get; init; }
         public ImmutableList<TimelineParticipant> Participants { get; init; } = ImmutableList<TimelineParticipant>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Match/TimelineParticipant.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Match/TimelineParticipant.cs
@@ -1,18 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Match
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record TimelineParticipant
+    public record TimelineParticipant : DataObject<TimelineParticipant>
     {
         public int ParticipantId { get; init; }
         public string Puuid { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/BannedChampion.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/BannedChampion.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
-    public record BannedChampion
+    public record BannedChampion : DataObject<BannedChampion>
     {
         /// <summary>
         /// The Draft Pick turn for when the champion was banned.
@@ -16,10 +14,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
         /// The banning team ID.
         /// </summary>
         public long TeamId { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/CurrentGameInfo.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/CurrentGameInfo.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
-    public record CurrentGameInfo
+    public record CurrentGameInfo : DataObject<CurrentGameInfo>
     {
         /// <summary>
         /// The game ID.
@@ -49,10 +48,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
         /// The information pertaining to participants.
         /// </summary>
         public ImmutableList<CurrentGameParticipant> Participants { get; init; } = ImmutableList<CurrentGameParticipant>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/CurrentGameParticipant.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/CurrentGameParticipant.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
-    public record CurrentGameParticipant
+    public record CurrentGameParticipant : DataObject<CurrentGameParticipant>
     {
         /// <summary>
         /// The played champion ID.
@@ -45,10 +44,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
         /// The list of Game Customization objects.
         /// </summary>
         public ImmutableList<GameCustomizationObject> GameCustomizationObjects { get; init; } = ImmutableList<GameCustomizationObject>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/FeaturedGameInfo.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/FeaturedGameInfo.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
-    public record FeaturedGameInfo
+    public record FeaturedGameInfo : DataObject<FeaturedGameInfo>
     {
         /// <summary>
         /// The selected game mode. See Riot Static Developer <see href="https://static.developer.riotgames.com/docs/lol/gameModes.json">gameModes.json</see>.
@@ -49,10 +48,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
         /// The platform ID the game is being played on.
         /// </summary>
         public string PlatformId { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/FeaturedGames.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/FeaturedGames.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
-    public record FeaturedGames
+    public record FeaturedGames : DataObject<FeaturedGames>
     {
         /// <summary>
         /// The list of featured games.
@@ -13,10 +12,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
         /// The suggested interval to wait before making another request for refreshing.
         /// </summary>
         public long ClientRefreshInterval { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/GameCustomizationObject.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/GameCustomizationObject.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
-    public record GameCustomizationObject
+    public record GameCustomizationObject : DataObject<GameCustomizationObject>
     {
         /// <summary>
         /// The category ID for Game Customization.
@@ -12,10 +10,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
         /// The content for Game Customization.
         /// </summary>
         public string Content { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/Observer.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/Observer.cs
@@ -1,17 +1,10 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
-    public record Observer
+    public record Observer : DataObject<Observer>
     {
         /// <summary>
         /// The key used to decrypt the spectator grid game data for playback.
         /// </summary>
         public string EncryptionKey { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/Participant.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/Participant.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
-    public record Participant
+    public record Participant : DataObject<Participant>
     {
         /// <summary>
         /// Whether this participant is a bot.
@@ -32,10 +30,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
         /// The first equipped summoner spell ID.
         /// </summary>
         public long Spell1Id { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/Perks.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Spectator/Perks.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
 {
-    public record Perks
+    public record Perks : DataObject<Perks>
     {
         /// <summary>
         /// The list of equipped perk/runes IDs.
@@ -17,10 +16,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Spectator
         /// The secondary runes path.
         /// </summary>
         public long PerkSubStyle { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/Summoner/SummonerDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/Summoner/SummonerDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.Summoner
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.Summoner
 {
-    public record SummonerDto
+    public record SummonerDto : DataObject<SummonerDto>
     {
         /// <summary>
         /// The encrypted account ID.
@@ -32,10 +30,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.Summoner
         /// The summoner level associated with summoner.
         /// </summary>
         public long SummonerLevel { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftLeague/LeagueEntryDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftLeague/LeagueEntryDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using BlossomiShymae.RiotBlossom.Dto.Riot.League;
+﻿using BlossomiShymae.RiotBlossom.Dto.Riot.League;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftLeague
 {
-    public record LeagueEntryDto
+    public record LeagueEntryDto : DataObject<LeagueEntryDto>
     {
         public string? LeagueId { get; init; } = default!;
         public string SummonerId { get; init; } = default!;
@@ -21,10 +20,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftLeague
         public bool? FreshBlood { get; init; }
         public bool? Inactive { get; init; }
         public MiniSeriesDto? MiniSeries { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftLeague/TopRatedLadderEntryDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftLeague/TopRatedLadderEntryDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftLeague
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftLeague
 {
-    public record TopRatedLadderEntryDto
+    public record TopRatedLadderEntryDto : DataObject<TopRatedLadderEntryDto>
     {
         /// <summary>
         /// The encrypted summoner ID.
@@ -25,10 +23,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftLeague
         /// </summary>
         public int Wins { get; init; }
         public int PreviousUpdateLadderPosition { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/CompanionDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/CompanionDto.cs
@@ -1,22 +1,16 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
 {
     /// <summary>
     /// UNDOCUMENTED
     /// </summary>
-    public record CompanionDto
+    public record CompanionDto : DataObject<CompanionDto>
     {
         [JsonPropertyName("skin_id")]
         public int SkinId { get; init; }
         [JsonPropertyName("content_id")]
         public string ContentId { get; init; } = default!;
         public string Species { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/InfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/InfoDto.cs
@@ -1,10 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
 {
-    public record InfoDto
+    public record InfoDto : DataObject<InfoDto>
     {
         /// <summary>
         /// The Unix timestamp.
@@ -40,10 +39,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
         /// </summary>
         [JsonPropertyName("tft_set_number")]
         public int TftSetNumber { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/MatchDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/MatchDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
 {
-    public record MatchDto
+    public record MatchDto : DataObject<MatchDto>
     {
         /// <summary>
         /// The match metadata.
@@ -12,10 +10,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
         /// The match info.
         /// </summary>
         public InfoDto Info { get; init; } = new();
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/MetadataDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/MetadataDto.cs
@@ -1,10 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
 {
-    public record MetadataDto
+    public record MetadataDto : DataObject<MetadataDto>
     {
         /// <summary>
         /// The match data version.
@@ -20,10 +19,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
         /// The list of active participant PUUIDs.
         /// </summary>
         public ImmutableList<string> Participants { get; init; } = ImmutableList<string>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/ParticipantDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/ParticipantDto.cs
@@ -1,10 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
 {
-    public record ParticipantDto
+    public record ParticipantDto : DataObject<ParticipantDto>
     {
         /// <summary>
         /// The participant's companion.
@@ -55,10 +54,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
         /// The list of active units.
         /// </summary>
         public ImmutableList<UnitDto> Units { get; init; } = ImmutableList<UnitDto>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/TraitDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/TraitDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
 {
-    public record TraitDto
+    public record TraitDto : DataObject<TraitDto>
     {
         /// <summary>
         /// The trait name.
@@ -28,10 +27,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
         /// </summary>
         [JsonPropertyName("tier_total")]
         public int TierTotal { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/UnitDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/TftMatch/UnitDto.cs
@@ -1,10 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
 {
-    public record UnitDto
+    public record UnitDto : DataObject<UnitDto>
     {
         /// <summary>
         /// The list of the unit's items.
@@ -31,10 +30,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.TftMatch
         /// The unit tier.
         /// </summary>
         public int Tier { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ActDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ActDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
 {
-    public record ActDto
+    public record ActDto : DataObject<ActDto>
     {
         public string Name { get; init; } = default!;
         /// <summary>
@@ -11,10 +9,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
         public LocalizedNamesDto? LocalizedNames { get; init; }
         public string Id { get; init; } = default!;
         public bool IsActive { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ContentDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ContentDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
 {
-    public record ContentDto
+    public record ContentDto : DataObject<ContentDto>
     {
         public string Version { get; init; } = default!;
         public ImmutableList<ContentItemDto> Characters { get; init; } = ImmutableList<ContentItemDto>.Empty;
@@ -20,10 +19,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
         public ImmutableList<ContentItemDto> PlayerCards { get; init; } = ImmutableList<ContentItemDto>.Empty;
         public ImmutableList<ContentItemDto> PlayerTitles { get; init; } = ImmutableList<ContentItemDto>.Empty;
         public ImmutableList<ActDto> Acts { get; init; } = ImmutableList<ActDto>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ContentItemDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/ContentItemDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
 {
-    public record ContentItemDto
+    public record ContentItemDto : DataObject<ContentItemDto>
     {
         public string Name { get; init; } = default!;
         /// <summary>
@@ -15,10 +13,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
         /// This is only included for maps and game modes.
         /// </summary>
         public string AssetPath { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/LocalizedNamesDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValContent/LocalizedNamesDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
 {
-    public record LocalizedNamesDto
+    public record LocalizedNamesDto : DataObject<LocalizedNamesDto>
     {
         [JsonPropertyName("ar-AE")]
         public string ArabicUAE { get; init; } = default!;
@@ -46,10 +45,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValContent
         public string ChineseSimplified { get; init; } = default!;
         [JsonPropertyName("zh-TW")]
         public string ChineseTaiwan { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/AbilityCastsDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/AbilityCastsDto.cs
@@ -1,17 +1,10 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record AbilityCastsDto
+    public record AbilityCastsDto : DataObject<AbilityCastsDto>
     {
         public int GrenadeCasts { get; init; }
         public int Ability1Casts { get; init; }
         public int Ability2Casts { get; init; }
         public int UltimateCasts { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/AbilityDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/AbilityDto.cs
@@ -1,17 +1,10 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record AbilityDto
+    public record AbilityDto : DataObject<AbilityDto>
     {
         public string GrenadeEffects { get; init; } = default!;
         public string Ability1Effects { get; init; } = default!;
         public string Ability2Effects { get; init; } = default!;
         public string UltimateEffects { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/CoachDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/CoachDto.cs
@@ -1,15 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record CoachDto
+    public record CoachDto : DataObject<CoachDto>
     {
         public string Puuid { get; init; } = default!;
         public string TeamId { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/DamageDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/DamageDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record DamageDto
+    public record DamageDto : DataObject<DamageDto>
     {
         /// <summary>
         /// The PUUID of affected player.
@@ -12,10 +10,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
         public int Legshots { get; init; }
         public int Bodyshots { get; init; }
         public int Headshots { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/EconomyDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/EconomyDto.cs
@@ -1,18 +1,11 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record EconomyDto
+    public record EconomyDto : DataObject<EconomyDto>
     {
         public int LoadoutValue { get; init; }
         public string Weapon { get; init; } = default!;
         public string Armor { get; init; } = default!;
         public int Remaining { get; init; }
         public int Spent { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/FinishingDamageDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/FinishingDamageDto.cs
@@ -1,16 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record FinishingDamageDto
+    public record FinishingDamageDto : DataObject<FinishingDamageDto>
     {
         public string DamageType { get; init; } = default!;
         public string DamageItem { get; init; } = default!;
         public bool IsSecondaryFireMode { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/KillDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/KillDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record KillDto
+    public record KillDto : DataObject<KillDto>
     {
         public int TimeSinceGameStartMillis { get; init; }
         public int TimeSinceRoundStartMillis { get; init; }
@@ -22,10 +21,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
         public ImmutableList<string> Assistants { get; init; } = ImmutableList<string>.Empty;
         public ImmutableList<PlayerLocationsDto> PlayerLocations { get; init; } = ImmutableList<PlayerLocationsDto>.Empty;
         public FinishingDamageDto FinishingDamage { get; init; } = new();
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/LocationDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/LocationDto.cs
@@ -1,15 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record LocationDto
+    public record LocationDto : DataObject<LocationDto>
     {
         public int X { get; init; }
         public int Y { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchDto.cs
@@ -1,19 +1,13 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record MatchDto
+    public record MatchDto : DataObject<MatchDto>
     {
         public MatchInfoDto MatchInfo { get; init; } = new();
         public ImmutableList<PlayerDto> Players { get; init; } = ImmutableList<PlayerDto>.Empty;
         public ImmutableList<CoachDto> Coaches { get; init; } = ImmutableList<CoachDto>.Empty;
         public ImmutableList<TeamDto> Teams { get; init; } = ImmutableList<TeamDto>.Empty;
         public ImmutableList<RoundResultDto> RoundResults { get; init; } = ImmutableList<RoundResultDto>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchInfoDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchInfoDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record MatchInfoDto
+    public record MatchInfoDto : DataObject<MatchInfoDto>
     {
         public string MatchId { get; init; } = default!;
         public string MapId { get; init; } = default!;
@@ -15,10 +13,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
         public string GameMode { get; init; } = default!;
         public bool IsRanked { get; init; }
         public string SeasonId { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchlistDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchlistDto.cs
@@ -1,16 +1,10 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record MatchlistDto
+    public record MatchlistDto : DataObject<MatchlistDto>
     {
         public string Puuid { get; init; } = default!;
         public ImmutableList<MatchlistEntryDto> History { get; init; } = ImmutableList<MatchlistEntryDto>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchlistEntryDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/MatchlistEntryDto.cs
@@ -1,16 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record MatchlistEntryDto
+    public record MatchlistEntryDto : DataObject<MatchlistEntryDto>
     {
         public string MatchId { get; init; } = default!;
         public long GameStartTimeMillis { get; init; }
         public string QueueId { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record PlayerDto
+    public record PlayerDto : DataObject<PlayerDto>
     {
         public string Puuid { get; init; } = default!;
         public string GameName { get; init; } = default!;
@@ -14,10 +12,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
         public int CompetitiveTier { get; init; }
         public string PlayerCard { get; init; } = default!;
         public string PlayerTitle { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerLocationsDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerLocationsDto.cs
@@ -1,16 +1,9 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record PlayerLocationsDto
+    public record PlayerLocationsDto : DataObject<PlayerLocationsDto>
     {
         public string Puuid { get; init; } = default!;
         public float ViewRadians { get; init; }
         public LocationDto Location { get; init; } = new();
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerRoundStatsDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerRoundStatsDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record PlayerRoundStatsDto
+    public record PlayerRoundStatsDto : DataObject<PlayerRoundStatsDto>
     {
         public string Puuid { get; init; } = default!;
         public ImmutableList<KillDto> Kills { get; init; } = ImmutableList<KillDto>.Empty;
@@ -11,10 +10,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
         public int Score { get; init; }
         public EconomyDto Economy { get; init; } = new();
         public AbilityDto Ability { get; init; } = new();
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerStatsDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/PlayerStatsDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record PlayerStatsDto
+    public record PlayerStatsDto : DataObject<PlayerStatsDto>
     {
         public int Score { get; init; }
         public int RoundsPlayed { get; init; }
@@ -11,10 +9,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
         public int Assists { get; init; }
         public int PlaytimeMillis { get; init; }
         public AbilityCastsDto AbilityCasts { get; init; } = new();
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/RecentMatchesDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/RecentMatchesDto.cs
@@ -1,16 +1,10 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record RecentMatchesDto
+    public record RecentMatchesDto : DataObject<RecentMatchesDto>
     {
         public long CurrentTime { get; init; }
         public ImmutableList<string> MatchIds { get; init; } = ImmutableList<string>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/RoundResultDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/RoundResultDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record RoundResultDto
+    public record RoundResultDto : DataObject<RoundResultDto>
     {
         public int RoundNum { get; init; }
         public string RoundResult { get; init; } = default!;
@@ -20,10 +19,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
         public LocationDto DefuseLocation { get; init; } = new();
         public ImmutableList<PlayerRoundStatsDto> PlayerStats { get; init; } = ImmutableList<PlayerRoundStatsDto>.Empty;
         public string RoundResultCode { get; init; } = default!;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/TeamDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValMatch/TeamDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
 {
-    public record TeamDto
+    public record TeamDto : DataObject<TeamDto>
     {
         /// <summary>
         /// The arbitrary string, being Red and Blue in bomb modes, the PUUID of the player in deathmatch.
@@ -24,10 +22,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValMatch
         /// The team points scored. Number of kills in deathmatch.
         /// </summary>
         public int NumPoints { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValRanked/LeaderboardDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValRanked/LeaderboardDto.cs
@@ -1,9 +1,8 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 
 namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValRanked
 {
-    public record LeaderboardDto
+    public record LeaderboardDto : DataObject<LeaderboardDto>
     {
         /// <summary>
         /// The shard for the given leaderboard.
@@ -21,10 +20,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValRanked
         /// The list of participating players.
         /// </summary>
         public ImmutableList<PlayerDto> Players { get; init; } = ImmutableList<PlayerDto>.Empty;
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossom/Dto/Riot/ValRanked/PlayerDto.cs
+++ b/BlossomiShymae.RiotBlossom/Dto/Riot/ValRanked/PlayerDto.cs
@@ -1,8 +1,6 @@
-﻿using BlossomiShymae.RiotBlossom.Core;
-
-namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValRanked
+﻿namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValRanked
 {
-    public record PlayerDto
+    public record PlayerDto : DataObject<PlayerDto>
     {
         /// <summary>
         /// The player UUID. May be omitted if player is anonymized.
@@ -19,10 +17,5 @@ namespace BlossomiShymae.RiotBlossom.Dto.Riot.ValRanked
         public long LeaderboardRank { get; init; }
         public long RankedRating { get; init; }
         public long NumberOfWins { get; init; }
-
-        public override string ToString()
-        {
-            return PrettyPrinter.GetString(this);
-        }
     }
 }

--- a/BlossomiShymae.RiotBlossomDocs/content/4.fundamentals/5.utilities.md
+++ b/BlossomiShymae.RiotBlossomDocs/content/4.fundamentals/5.utilities.md
@@ -147,6 +147,12 @@ IEnumerable`1[KeyValuePair`2] [
 ]
 ```
 
+There is also a method overload that allows you to set the type label prefix! <3
+
+```csharp
+PrettyPrinter.GetString(itemDictionary, "Items")
+```
+
 ## RegionMapper
 
 Maps a `Region` enum to a string representation used for the Riot API. Can also be 

--- a/BlossomiShymae.RiotBlossomTests/Dto/DataObjectTests.cs
+++ b/BlossomiShymae.RiotBlossomTests/Dto/DataObjectTests.cs
@@ -22,11 +22,6 @@ namespace BlossomiShymae.RiotBlossomTests.Dto
         {
             public string? Id { get; init; }
             public string? Name { get; init; }
-
-            public ExampleDto()
-            {
-                Data = this;
-            }
         }
     }
 }

--- a/BlossomiShymae.RiotBlossomTests/Dto/DataObjectTests.cs
+++ b/BlossomiShymae.RiotBlossomTests/Dto/DataObjectTests.cs
@@ -1,0 +1,32 @@
+﻿using BlossomiShymae.RiotBlossom.Dto;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Diagnostics;
+
+namespace BlossomiShymae.RiotBlossomTests.Dto
+{
+    [TestClass()]
+    public class DataObjectTests
+    {
+        [TestMethod()]
+        public void DataObject_WithInheritance_ShouldReturnPrettyString()
+        {
+            ExampleDto child = new();
+
+            string prettyString = child.ToString();
+            Trace.WriteLine(prettyString);
+
+            Assert.IsTrue(prettyString.Length > 0);
+        }
+
+        public record ExampleDto : DataObject<ExampleDto>
+        {
+            public string? Id { get; init; }
+            public string? Name { get; init; }
+
+            public ExampleDto()
+            {
+                Data = this;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #27 ! >:3

# Features
- **Core.PrettyPrinter**: Add overload method `GetPrettyString` for manually setting the class name
- **Dto**: Add abstract `DataObject<T>` superclass for namespace
- **Dto**: All objects now extend from the above class